### PR TITLE
feat: add LinkedIn outreach module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,9 @@ TELEGRAM_BOT_TOKEN=
 # Your own Telegram numeric chat id, so the bot only ever answers you.
 # Find it by messaging @userinfobot on Telegram.
 TELEGRAM_ALLOWED_CHAT_ID=
+
+# --- LinkedIn outreach module ---------------------------------------------
+# Optional. The linkedin-outreach module needs no credentials. This only caps
+# how many invites it lets you draft and send per day. Leave blank for the
+# default of 5.
+LINKEDIN_OUTREACH_DAILY_CAP=

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The core runs with zero external services. Modules add capability when you want 
 | `proactive` | Available | Scheduled automation: a morning brief and weekly review on a timer |
 | `telegram` | Available | A Telegram bot: inbound messages drafted for your approval, never auto-sent |
 | `integrations` | Available | MCP tools: browser automation, web search, Gmail, Calendar, utilities |
+| `linkedin-outreach` | Available | Drafts one LinkedIn connection-invitation card a day from a queue, for your review and manual send |
 | `memory-search` | Roadmap | Semantic search over your memory and vault (needs a local embedding model) |
 | `extra-agents` | Roadmap | An agent gallery: designer, evaluator, sales coach, project manager |
 | `whatsapp` | Roadmap | WhatsApp channel — not built (account-ban risk); use Telegram instead |

--- a/config/user.config.yaml.template
+++ b/config/user.config.yaml.template
@@ -21,6 +21,7 @@ modules:
   proactive: false       # scheduled automation (morning brief, weekly review)
   telegram: false        # Telegram bot — inbound messages drafted for your approval
   integrations: false    # MCP integrations (web, Google Workspace, search, utility)
+  linkedin_outreach: false  # daily LinkedIn outreach drafting (queue-driven, draft-first)
   memory_search: false   # semantic search over memory and the vault
   extra_agents: false    # the extra-agents gallery
   team: false            # multi-user team mode

--- a/modules/README.md
+++ b/modules/README.md
@@ -7,6 +7,7 @@ The core kit runs with zero external services. Modules add capability when you w
 | [`proactive/`](proactive/) | **Available** | Scheduled automation: a morning brief and a weekly review that run on a timer and leave their output in `reports/`. |
 | [`telegram/`](telegram/) | **Available** | A Telegram bot. Inbound messages are drafted for your approval; it never auto-sends. Bot-token based, polling. |
 | [`integrations/`](integrations/) | **Available** | An MCP integration picker: web + browser tools, Google Workspace, web search, and utilities. Run `scripts/install-integrations.sh`. |
+| [`linkedin-outreach/`](linkedin-outreach/) | **Available** | Daily LinkedIn connection-invitation drafting from a queue you keep: it decides hook vs. no-note and writes a review card. You send it; it never sends. |
 | [`memory-search/`](memory-search/) | **Available** | A search index over memory and the vault: ranked keyword search out of the box, semantic (search by meaning) with Ollama. Built by the `/index-memory` skill. |
 | [`extra-agents/`](extra-agents/) | Roadmap | A gallery of additional agents (designer, evaluator, sales coach, project manager) to copy into `.claude/agents/`. |
 | [`whatsapp/`](whatsapp/) | Roadmap | A WhatsApp channel. Not built: unofficial bridges risk an account ban. Use the Telegram module instead. |

--- a/modules/linkedin-outreach/README.md
+++ b/modules/linkedin-outreach/README.md
@@ -1,0 +1,138 @@
+# Module: LinkedIn outreach
+
+Drafts your LinkedIn connection invitations, one a day, from a queue you keep.
+For each person it decides whether there is a genuine reason to attach a note or
+whether a clean no-note invite is the better call, writes the note when there
+is one, and hands you a review card. **It never sends anything.** You read the
+card, send the invite yourself on LinkedIn, and record what you did.
+
+It is the same draft-first contract the kit applies to email and Telegram: the
+assistant does the judgment and the writing, you keep the send.
+
+## The idea: a note only when there is a real hook
+
+Most connection requests are better off with no note at all. A generic note
+("connecting with other people in growth...") does not improve acceptance and
+can faintly hurt it, because anyone who knows LinkedIn reads a note as the start
+of a pitch. A note earns its place only when there is a **genuine hook**:
+something specific and true about that person (you met somewhere, a mutual
+connection, a shared past employer, a rare title, a real recent move).
+
+So the module is hook-gated. If your context note on a person carries a real
+hook, it drafts one honest line. If it does not, it tells you to send a bare
+invite. That decision, made well and consistently, is most of the value here.
+
+## How it works
+
+- You keep a queue at `vault/LinkedIn Outreach Queue.md`: one person per line,
+  topmost first, each with a short context note.
+- `draft.sh` takes the person at the top of the queue, decides hook or no-hook,
+  drafts the note if warranted, and writes a review card to
+  `reports/linkedin-outreach/cards/`.
+- You open the card, send the invite on LinkedIn yourself, then run `record.sh`
+  to log the outcome. That moves the person out of the queue and frees the slot
+  for the next draft.
+
+Only one card is open at a time, and there is a daily cap, so the queue drains
+at a deliberate, human pace.
+
+## Why you send it yourself
+
+LinkedIn's terms restrict automated activity, and tools that send invites for
+you work by driving a logged-in session, which puts your account at risk. This
+module does not do that. It does the part that actually takes thought, deciding
+who to reach and what to write, and leaves the click to you. If you already run
+a LinkedIn automation MCP server and accept that trade-off, see "Wiring an
+automated send" at the end.
+
+## Setup
+
+No credentials, no API keys.
+
+1. The first time you run `draft.sh`, it creates the queue file for you at
+   `vault/LinkedIn Outreach Queue.md` and stops.
+2. Open that file and add people to the `## Queue` section. Line format:
+   ```
+   - [ ] https://www.linkedin.com/in/their-slug | who they are, and any genuine hook
+   ```
+   The context note after the `|` is the important part. Write a real, specific
+   hook and you get a real note. Write something generic, or nothing, and you
+   get a clean no-note invite, which is the right call when there is no hook.
+   You can add people by hand, or ask your assistant in a session to suggest
+   connections from your notes and meetings.
+3. Set `linkedin_outreach: true` in `config/user.config.yaml`.
+
+## Use it
+
+Draft a card whenever you want one:
+
+```bash
+bash modules/linkedin-outreach/draft.sh
+```
+
+It prints where the card landed. Open it: it shows the person, your context
+note, the hook-or-no-hook decision, and the drafted note (or a note-free
+recommendation). To change the wording, just edit the card file.
+
+### Send it, then record it
+
+The card has the profile link and the exact note text. On LinkedIn, open the
+profile, click **Connect**, and either "Add a note" and paste the text, or send
+with no note for a bare invite.
+
+Then record what you did, so the queue stays in sync:
+
+```bash
+bash modules/linkedin-outreach/record.sh <card-file> sent
+```
+
+Use `rejected` if you looked at the card and decided not to reach out, or
+`skipped` if the profile was wrong or you are already connected. Recording
+archives the card and frees the slot for the next `draft.sh`.
+
+## Run it on a schedule (optional)
+
+To draft a card automatically every weekday morning:
+
+```bash
+bash modules/linkedin-outreach/install.sh
+```
+
+It generates a schedule file (a launchd plist on macOS, a cron line on Linux)
+and prints the one command to activate it. It does not touch your scheduler on
+its own. The scheduled run skips weekends; a manual `draft.sh` never does.
+
+A scheduled run only ever drafts a card. Nothing is sent, so you still review
+and send every invite by hand.
+
+## The daily cap
+
+The module drafts, and lets you send, at most a few invites a day (default 5).
+LinkedIn enforces its own weekly invite limits, and a steady trickle reads far
+better than a burst. To change the cap, set `LINKEDIN_OUTREACH_DAILY_CAP` in
+`.env`.
+
+## Cost note
+
+Each `draft.sh` run is one headless `claude -p` call, pinned to `--model sonnet`
+to keep it modest. It runs on your Claude subscription or API credits like any
+other session.
+
+## Pairs well with
+
+The `crm-relationships` agent tracks who you know and who you have reached out
+to. Ask it to review your network for people worth queuing.
+
+## Disable it
+
+If you scheduled it, remove the schedule (the deactivation command is printed by
+`install.sh`). Set `linkedin_outreach: false` in `config/user.config.yaml`. Your
+queue file and any archived cards stay where they are.
+
+## Wiring an automated send (advanced, optional)
+
+If you run a LinkedIn MCP server that can send a connection request, and you
+accept the terms-of-service trade-off, you can close the loop yourself: have
+your assistant call that MCP tool with the `linkedin_url` and note text from a
+card, then run `record.sh <card> sent`. This module deliberately does not ship
+or depend on such a server.

--- a/modules/linkedin-outreach/_outreach.py
+++ b/modules/linkedin-outreach/_outreach.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Compabob LinkedIn outreach module helper.
+
+Two subcommands:
+
+  preflight [--enforce-weekday]
+      Decide whether it is OK to draft a new outreach card right now.
+      Exit 0 = clear to draft (a one-line status is printed).
+      Exit 1 = a gate failed; the reason is printed on stdout.
+      Side effect: the first time it runs, it creates the queue file at
+      vault/LinkedIn Outreach Queue.md from the shipped seed.
+
+  record <card-file> <sent|rejected|skipped>
+      Record the outcome of a drafted card: move its queue line into the
+      matching section of the queue file, stamp the card, and archive it.
+
+No external dependencies; standard library only.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+MODULE_DIR = Path(__file__).resolve().parent
+PROJECT_DIR = MODULE_DIR.parent.parent
+QUEUE_FILE = PROJECT_DIR / "vault" / "LinkedIn Outreach Queue.md"
+SEED_FILE = MODULE_DIR / "queue.example.md"
+CARDS_DIR = PROJECT_DIR / "reports" / "linkedin-outreach" / "cards"
+ARCHIVE_DIR = CARDS_DIR / "archive"
+
+DEFAULT_DAILY_CAP = 5
+OUTCOME_SECTION = {"sent": "Sent", "rejected": "Rejected", "skipped": "Skipped"}
+
+
+def fail(reason: str) -> None:
+    print(reason)
+    sys.exit(1)
+
+
+def rel(p: Path) -> str:
+    try:
+        return str(p.relative_to(PROJECT_DIR))
+    except ValueError:
+        return str(p)
+
+
+def daily_cap() -> int:
+    raw = os.environ.get("LINKEDIN_OUTREACH_DAILY_CAP", "").strip()
+    if raw.isdigit() and int(raw) > 0:
+        return int(raw)
+    return DEFAULT_DAILY_CAP
+
+
+# --- queue file -----------------------------------------------------------
+
+
+def unchecked_queue_entries() -> list[str]:
+    """Return the raw '- [ ] ' lines under the '## Queue' heading."""
+    if not QUEUE_FILE.exists():
+        return []
+    out: list[str] = []
+    in_queue = False
+    for line in QUEUE_FILE.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            in_queue = stripped == "## Queue"
+            continue
+        if in_queue and stripped.startswith("- [ ] "):
+            out.append(line)
+    return out
+
+
+def move_queue_line(queue_line: str, dest_section: str, annotation: str) -> bool:
+    """Remove queue_line from '## Queue' and append it (annotated) to dest_section.
+
+    Returns True if the line was found and moved. Idempotent-ish: if the line is
+    not under '## Queue' anymore, returns False and changes nothing.
+    """
+    if not QUEUE_FILE.exists() or not queue_line.strip():
+        return False
+    target = queue_line.strip()
+    lines = QUEUE_FILE.read_text(encoding="utf-8").splitlines()
+
+    section = None
+    queue_idx = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            section = stripped[3:].strip()
+        elif section == "Queue" and stripped == target:
+            queue_idx = i
+    if queue_idx is None:
+        return False
+
+    annotated = f"{lines[queue_idx]}  <!-- {annotation} -->"
+    del lines[queue_idx]
+
+    dest_idx = next(
+        (j for j, ln in enumerate(lines) if ln.strip() == f"## {dest_section}"),
+        None,
+    )
+    if dest_idx is None:
+        lines += ["", f"## {dest_section}", "", annotated]
+    else:
+        insert_at = dest_idx + 1
+        while insert_at < len(lines) and lines[insert_at].strip() == "":
+            insert_at += 1
+        lines.insert(insert_at, annotated)
+
+    QUEUE_FILE.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True
+
+
+# --- cards ----------------------------------------------------------------
+
+
+def open_cards() -> list[Path]:
+    """Cards drafted but not yet recorded (directly in cards/, not archive/)."""
+    if not CARDS_DIR.exists():
+        return []
+    return sorted(p for p in CARDS_DIR.glob("*.md"))
+
+
+def parse_frontmatter(path: Path) -> dict[str, str]:
+    """Parse a simple key: value YAML-ish frontmatter block. First colon splits."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    fm: dict[str, str] = {}
+    for line in text.splitlines()[1:]:
+        if line.strip() == "---":
+            break
+        if ":" in line:
+            key, value = line.split(":", 1)
+            fm[key.strip()] = value.strip()
+    return fm
+
+
+def count_sent_today() -> int:
+    if not ARCHIVE_DIR.exists():
+        return 0
+    today = date.today().isoformat()
+    n = 0
+    for p in ARCHIVE_DIR.glob("*.md"):
+        fm = parse_frontmatter(p)
+        if fm.get("outcome") == "sent" and fm.get("recorded", "").startswith(today):
+            n += 1
+    return n
+
+
+def stamp_frontmatter(text: str, outcome: str, today: str) -> str:
+    """Set 'outcome:' and add/replace 'recorded:' in the card's frontmatter."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+    end = next((i for i in range(1, len(lines)) if lines[i].strip() == "---"), None)
+    if end is None:
+        return text
+
+    out: list[str] = []
+    saw_outcome = saw_recorded = False
+    for i, line in enumerate(lines):
+        key = line.split(":", 1)[0].strip() if ":" in line else ""
+        if 0 < i < end and key == "outcome":
+            out.append(f"outcome: {outcome}")
+            saw_outcome = True
+        elif 0 < i < end and key == "recorded":
+            out.append(f"recorded: {today}")
+            saw_recorded = True
+        elif i == end:
+            if not saw_outcome:
+                out.append(f"outcome: {outcome}")
+            if not saw_recorded:
+                out.append(f"recorded: {today}")
+            out.append(line)
+        else:
+            out.append(line)
+    return "\n".join(out) + ("\n" if text.endswith("\n") else "")
+
+
+# --- subcommands ----------------------------------------------------------
+
+
+def cmd_preflight(enforce_weekday: bool) -> None:
+    if not QUEUE_FILE.exists():
+        QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        if SEED_FILE.exists():
+            shutil.copy(SEED_FILE, QUEUE_FILE)
+        else:  # defensive: seed missing, write a minimal queue
+            QUEUE_FILE.write_text(
+                "# LinkedIn Outreach Queue\n\n## Queue\n\n"
+                "## Sent\n\n## Rejected\n\n## Skipped\n",
+                encoding="utf-8",
+            )
+        fail(
+            f"created your queue at {rel(QUEUE_FILE)}. "
+            f"Add people to its '## Queue' section, then run draft.sh again."
+        )
+
+    if enforce_weekday and datetime.now().weekday() >= 5:
+        fail(
+            f"weekend ({datetime.now():%A}); the scheduled run skips weekends. "
+            f"Run draft.sh by hand if you want a card anyway."
+        )
+
+    opened = open_cards()
+    if opened:
+        fail(
+            f"a card is still open ({opened[0].name}). Act on it and run "
+            f"record.sh before drafting another."
+        )
+
+    cap = daily_cap()
+    sent = count_sent_today()
+    if sent >= cap:
+        fail(
+            f"daily cap reached ({sent}/{cap} sent today). Next card tomorrow, "
+            f"or raise LINKEDIN_OUTREACH_DAILY_CAP in .env."
+        )
+
+    entries = unchecked_queue_entries()
+    if not entries:
+        fail(
+            f"the queue is empty. Add people to the '## Queue' section of "
+            f"{rel(QUEUE_FILE)}."
+        )
+
+    print(f"clear: {len(entries)} queued, {sent}/{cap} sent today.")
+    sys.exit(0)
+
+
+def cmd_record(card_arg: str, outcome: str) -> None:
+    if outcome not in OUTCOME_SECTION:
+        fail(f"unknown outcome '{outcome}'. Use: sent, rejected, or skipped.")
+
+    p = Path(card_arg)
+    card = next(
+        (c for c in (p, CARDS_DIR / card_arg, CARDS_DIR / p.name) if c.is_file()),
+        None,
+    )
+    if card is None:
+        if (ARCHIVE_DIR / p.name).is_file():
+            fail(f"{p.name} was already recorded (it is in {rel(ARCHIVE_DIR)}).")
+        fail(f"card not found: {card_arg}\nLook in {rel(CARDS_DIR)} for the file name.")
+
+    fm = parse_frontmatter(card)
+    queue_line = fm.get("queue_line", "")
+    if not queue_line:
+        fail(
+            f"{card.name} has no 'queue_line' in its frontmatter; "
+            f"cannot sync the queue. Move the entry by hand."
+        )
+
+    today = date.today().isoformat()
+    moved = move_queue_line(queue_line, OUTCOME_SECTION[outcome], f"{outcome} {today}")
+
+    ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+    stamped = stamp_frontmatter(card.read_text(encoding="utf-8"), outcome, today)
+    (ARCHIVE_DIR / card.name).write_text(stamped, encoding="utf-8")
+    card.unlink()
+
+    queue_note = "" if moved else " (queue line not found; queue left unchanged)"
+    print(
+        f"recorded {card.name} as {outcome}; moved to {OUTCOME_SECTION[outcome]} "
+        f"in the queue{queue_note}. Card archived under {rel(ARCHIVE_DIR)}."
+    )
+    sys.exit(0)
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if not args:
+        fail(
+            "usage: _outreach.py preflight [--enforce-weekday]\n"
+            "       _outreach.py record <card-file> <sent|rejected|skipped>"
+        )
+    if args[0] == "preflight":
+        cmd_preflight("--enforce-weekday" in args[1:])
+    elif args[0] == "record":
+        if len(args) != 3:
+            fail("usage: _outreach.py record <card-file> <sent|rejected|skipped>")
+        cmd_record(args[1], args[2])
+    else:
+        fail(f"unknown subcommand: {args[0]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/linkedin-outreach/draft.sh
+++ b/modules/linkedin-outreach/draft.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Compabob LinkedIn outreach: draft one invitation card for your review.
+#
+# Picks the person at the top of your queue, decides whether a genuine hook
+# calls for a one-line note or a clean no-note invite, and writes a review card
+# to reports/linkedin-outreach/cards/. It NEVER sends anything. You review the
+# card, send the invite yourself on LinkedIn, then run record.sh.
+#
+#   usage: bash modules/linkedin-outreach/draft.sh
+#          bash modules/linkedin-outreach/draft.sh --scheduled  (used by install.sh; skips weekends)
+set -uo pipefail
+
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$MODULE_DIR/../.." && pwd)"
+cd "$PROJECT_DIR"
+
+# launchd and cron run with a minimal PATH; put common tool dirs on it so the
+# claude and python3 binaries are found when this runs unattended.
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
+
+[ -f .env ] && { set -a; . ./.env; set +a; }
+
+for c in claude python3; do
+  command -v "$c" >/dev/null 2>&1 || { echo "$c not found, it is required." >&2; exit 1; }
+done
+
+PRE_FLAG=""
+[ "${1:-}" = "--scheduled" ] && PRE_FLAG="--enforce-weekday"
+
+OUT_DIR="$PROJECT_DIR/reports/linkedin-outreach"
+mkdir -p "$OUT_DIR/cards"
+LOG="$OUT_DIR/draft.log"
+
+# Preflight: weekday (when scheduled), one card at a time, daily cap, queue not
+# empty. On any fail it prints a plain reason and we stop quietly.
+if ! REASON="$(python3 "$MODULE_DIR/_outreach.py" preflight $PRE_FLAG)"; then
+  echo "$REASON"
+  exit 0
+fi
+echo "$REASON"
+echo "Drafting a card with claude -p (model: sonnet)..."
+
+claude -p "$(cat "$MODULE_DIR/prompts/draft-note.md")" \
+  --model sonnet \
+  --allowedTools "Read,Write" 2>&1 | tee -a "$LOG"
+
+echo
+CARD="$(ls -t "$OUT_DIR"/cards/*.md 2>/dev/null | head -1)"
+if [ -n "${CARD:-}" ] && [ -f "$CARD" ]; then
+  echo "Review the card:"
+  echo "  $CARD"
+  echo
+  echo "When you have acted on it, record the outcome:"
+  echo "  bash modules/linkedin-outreach/record.sh \"$CARD\" sent"
+  echo "  (use 'rejected' if you decide not to reach out, 'skipped' if the profile was wrong)"
+else
+  echo "No card file was written. Check the output above or $LOG."
+fi

--- a/modules/linkedin-outreach/install.sh
+++ b/modules/linkedin-outreach/install.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Compabob LinkedIn outreach module: optional weekday-morning scheduler.
+#
+# The default, supported way to use this module is by hand:
+#     bash modules/linkedin-outreach/draft.sh
+# This script is only for drafting a card automatically every weekday morning.
+# It GENERATES the schedule file and prints the command to activate it; it never
+# touches your system scheduler on its own.
+set -euo pipefail
+
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$MODULE_DIR/../.." && pwd)"
+GEN_DIR="$MODULE_DIR/generated"
+DRAFT="$MODULE_DIR/draft.sh"
+mkdir -p "$GEN_DIR" "$PROJECT_DIR/reports/linkedin-outreach"
+
+OS="$(uname -s)"
+echo "LinkedIn outreach module installer (OS: $OS)"
+echo
+
+if [ "$OS" = "Darwin" ]; then
+  LABEL="com.compabob.linkedin-outreach"
+  PLIST="$GEN_DIR/$LABEL.plist"
+  WEEKDAYS=""
+  for d in 1 2 3 4 5; do
+    WEEKDAYS="$WEEKDAYS    <dict><key>Weekday</key><integer>$d</integer><key>Hour</key><integer>8</integer><key>Minute</key><integer>0</integer></dict>
+"
+  done
+  cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>$DRAFT</string>
+    <string>--scheduled</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <array>
+$WEEKDAYS  </array>
+  <key>StandardOutPath</key><string>$PROJECT_DIR/reports/linkedin-outreach/launchd.out</string>
+  <key>StandardErrorPath</key><string>$PROJECT_DIR/reports/linkedin-outreach/launchd.err</string>
+</dict>
+</plist>
+EOF
+  echo "  generated $PLIST"
+  echo
+  echo "To activate (drafts a card every weekday at 08:00), run:"
+  echo "  cp \"$PLIST\" ~/Library/LaunchAgents/"
+  echo "  launchctl load ~/Library/LaunchAgents/$LABEL.plist"
+  echo
+  echo "To stop later:"
+  echo "  launchctl unload ~/Library/LaunchAgents/$LABEL.plist && rm ~/Library/LaunchAgents/$LABEL.plist"
+
+elif [ "$OS" = "Linux" ]; then
+  CRON_FILE="$GEN_DIR/crontab.txt"
+  cat > "$CRON_FILE" <<EOF
+# Compabob LinkedIn outreach. Drafts one card each weekday at 08:00.
+0 8 * * 1-5  cd "$PROJECT_DIR" && bash "$DRAFT" --scheduled
+EOF
+  echo "  generated $CRON_FILE"
+  echo
+  echo "To activate, add that line to your crontab:"
+  echo "  crontab -e        # then paste the contents of $CRON_FILE"
+  echo
+  echo "To deactivate later: remove that line with crontab -e."
+
+else
+  echo "Unsupported OS for automatic scheduling: $OS"
+  echo "Run the module by hand instead:  bash modules/linkedin-outreach/draft.sh"
+  exit 1
+fi
+
+echo
+echo "A scheduled run only ever drafts a card. Nothing is sent: you still review"
+echo "and send every invite by hand."
+echo
+echo "After activating, set  linkedin_outreach: true  in config/user.config.yaml."

--- a/modules/linkedin-outreach/prompts/draft-note.md
+++ b/modules/linkedin-outreach/prompts/draft-note.md
@@ -1,0 +1,169 @@
+# Draft one LinkedIn outreach card
+
+You are this user's assistant, drafting one LinkedIn connection-invitation card
+for them to review. **You do not send anything.** You pick one person from their
+queue, decide whether to attach a note, draft it if warranted, and write a
+review card to a file. The user reviews the card, sends the invite themselves on
+LinkedIn, and records the outcome.
+
+## Step 1: Read who the user is
+
+Read `config/user.config.yaml` for the user's name and role. Read
+`memory/topics/role-and-priorities.md` for what they currently work on and care
+about. This is the user's positioning: it anchors the one line of self-
+disclosure in any note you write. If those files are missing or still contain
+bracketed placeholder text, work from whatever you can find and keep the self-
+disclosure short and generic.
+
+## Step 2: Read the queue and pick a person
+
+Open `vault/LinkedIn Outreach Queue.md`. The `## Queue` section has lines like:
+
+```
+- [ ] https://www.linkedin.com/in/their-slug | context note from the user
+```
+
+Pick the **topmost** unchecked `- [ ] ` line in `## Queue`. That is your one
+person for this run. A preflight check already guaranteed at least one entry
+exists. Do not pick from `## Sent`, `## Rejected`, or `## Skipped`.
+
+Parse from the line:
+- **linkedin_url**: the URL. If only a slug is given, build
+  `https://www.linkedin.com/in/<slug>`.
+- **slug**: the `/in/<slug>` portion, lowercased, every non-alphanumeric
+  character replaced with `-`, truncated to 40 characters.
+- **context**: everything after the first ` | `. May be empty.
+
+You work only from this context note and the URL. You do not browse LinkedIn.
+The context note is your only source of truth about this person.
+
+## Step 3: Decide, note or no note?
+
+**Default to no note.** A connection request with a generic note ("connecting
+with other people in growth...") does not lift acceptance and can faintly hurt
+it: anyone who knows LinkedIn reads a note as the opening of a pitch. A note
+earns its place only when there is a **genuine hook**.
+
+A genuine hook is something specific and true about *this* person that gives a
+real reason to write a line. It must come from the user's context note.
+Qualifying hooks:
+
+- A specific shared thing: "met at [event]", "mutual connection with [name]",
+  "we both worked at [company]", "they wrote [a named piece]".
+- A notably rare or exact-match title relative to the user's own focus.
+- A recent, real move: a job change that is a genuine step.
+- A demonstrated overlap with what the user actually works on (from Step 1),
+  where the context note shows this person shares that interest.
+
+NOT hooks, treat these as no-hook: generic firmographics ("Series B, 200
+people"), generic seniority, "impressive background", "fast-growing company",
+"love their content" with nothing specific, or an empty context note.
+
+## Step 4: Compose
+
+### No genuine hook: bare invite
+
+Set the draft note to empty. The card will tell the user to send a connection
+request with no note. This is the expected, correct outcome for most people, not
+a failure.
+
+### Genuine hook: one short note
+
+Voice: a real person writing one line to a peer. Not marketing. Structure:
+
+> [Greeting] [Name], [one-line genuine hook]. [One line of who the user is and
+> what they are focused on, from Step 1]. [Optional soft close]. [User's first name]
+
+Rules:
+
+1. **One genuine hook line, first.** Something only true of this person, not
+   flattery.
+2. **One line of the user's own context** (their role and current focus, from
+   Step 1). This is their credibility anchor. Keep it true and specific.
+3. **No ask.** Never "would love 15 minutes", "let's chat", "open to a call",
+   "can you intro me". A soft "would be good to compare notes" or "glad to
+   connect" is the ceiling.
+4. **Sign with the user's first name.** Drop the signature only if length
+   forces it.
+5. **No pitch, no link, no calendar suggestion, no "I help X do Y" framing, no
+   "looking to learn from you" deference.**
+6. **No em dashes.** Use commas or periods.
+7. **Greeting matches the target's likely language** if the context note
+   signals one (Hi or Hello in English, Hola in Spanish, Hallo in German);
+   otherwise use the user's primary language, or English.
+
+Worked examples. Copy the shape, not the wording:
+
+> Hi Jane, GTM Engineer is still a rare title, it caught my eye. I spend most of
+> my time on RevOps tooling these days, would be good to compare notes. Alex
+
+> Hola Marco, we both did time at Acme, good to see where you landed. I am deep
+> in growth analytics at the moment, glad to connect. Alex
+
+Hard limits: **maximum 200 characters** (LinkedIn allows 300, leave headroom),
+1 to 3 sentences, the signature does not count as a sentence.
+
+## Step 5: Write the review card
+
+Write a file to `reports/linkedin-outreach/cards/card-<YYYY-MM-DD>-<slug>.md`,
+using today's date. Use exactly this structure:
+
+```
+---
+queue_line: <the queue line, copied verbatim character for character, including the leading "- [ ] ">
+linkedin_url: <the URL>
+slug: <the slug>
+name: <the person's name if the context note gives one, otherwise the slug>
+created: <YYYY-MM-DD>
+outcome: open
+---
+
+# LinkedIn outreach card: <name>
+
+- **Profile:** <linkedin_url>
+- **Your context note:** <the context, or "(none)">
+- **Decision:** note   (or: bare invite, no note)
+
+## Draft note (NOT sent)
+
+<For a real note: the note text, plain, ready to copy. Then a blank line, then:>
+(<N> / 200 characters)
+
+<For a bare invite, instead of the above write exactly this line:>
+_Bare invite: send the connection request with no note._
+
+## Why
+
+<One or two sentences: which hook you used and how it shaped the note, or why
+there was no genuine hook so this is a bare invite.>
+
+---
+
+## How to act on this card
+
+1. Review the draft above. To change the note, edit this file directly.
+2. Open the profile: <linkedin_url>
+3. On LinkedIn, click **Connect**. For a note, choose "Add a note" and paste the
+   text above. For a bare invite, just send the request.
+4. Record what you did so the queue stays in sync:
+   - `bash modules/linkedin-outreach/record.sh <the file name of this card> sent`
+   - use `rejected` if you decided not to reach out, `skipped` if the profile
+     was wrong or you are already connected.
+```
+
+The `queue_line` field is critical: `record.sh` uses it to find and move the
+entry in the queue. Copy it verbatim.
+
+## Hard rules
+
+- Do **not** send anything. Do not call any LinkedIn or messaging tool. This run
+  only reads files and writes one card file.
+- Write **exactly one** card.
+- Do **not** modify the queue file. `record.sh` handles all queue changes later.
+- Pick only from `## Queue`, only the topmost unchecked entry.
+- An empty draft note (a bare invite) is a valid, normal result. The absence of
+  a hook is not a failure.
+
+## Finally
+
+Print one line: the path of the card file you wrote.

--- a/modules/linkedin-outreach/queue.example.md
+++ b/modules/linkedin-outreach/queue.example.md
@@ -1,0 +1,32 @@
+# LinkedIn Outreach Queue
+
+> The people you want to connect with on LinkedIn. The linkedin-outreach module
+> reads this file, takes the person at the top of `## Queue`, and drafts one
+> connection-invitation card for your review. It never sends anything.
+>
+> Add people to `## Queue`, topmost first, one per line, in this format:
+>
+>     - [ ] https://www.linkedin.com/in/their-slug | who they are, and any genuine hook
+>
+> The context note after the `|` is the important part. A specific, true hook
+> (where you met, a mutual connection, a shared past employer, a rare title, a
+> real recent move) gets you one honest line. A generic note, or no note, gets a
+> clean no-note invite, which is the right call when there is no hook. Do not
+> invent hooks.
+>
+> Examples of good lines:
+>
+>     - [ ] https://www.linkedin.com/in/jane-doe | met at the SaaS Growth meetup in March, runs RevOps at a Series B fintech
+>     - [ ] https://www.linkedin.com/in/marco-rossi | ex-colleague from Acme, now heads growth at a logistics startup
+>     - [ ] https://www.linkedin.com/in/sam-lee | no specific hook, just want to connect
+>
+> When you record a card with record.sh, the person moves into one of the
+> sections below. Leave those section headings in place.
+
+## Queue
+
+## Sent
+
+## Rejected
+
+## Skipped

--- a/modules/linkedin-outreach/record.sh
+++ b/modules/linkedin-outreach/record.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Compabob LinkedIn outreach: record what you did with a drafted card.
+#
+# After you act on a card (send the invite on LinkedIn, or decide not to), run
+# this so the module moves the person out of '## Queue' into the right section
+# of your queue file and archives the card. Recording also frees the slot for
+# the next draft.
+#
+#   usage: bash modules/linkedin-outreach/record.sh <card-file> <sent|rejected|skipped>
+set -uo pipefail
+
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$MODULE_DIR/../.." && pwd)"
+cd "$PROJECT_DIR"
+
+CARD="${1:-}"
+OUTCOME="${2:-}"
+if [ -z "$CARD" ] || [ -z "$OUTCOME" ]; then
+  echo "usage: record.sh <card-file> <sent|rejected|skipped>" >&2
+  echo "  card-file: a card from reports/linkedin-outreach/cards/ (file name or path)" >&2
+  exit 1
+fi
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 not found, it is required." >&2; exit 1; }
+exec python3 "$MODULE_DIR/_outreach.py" record "$CARD" "$OUTCOME"


### PR DESCRIPTION
## What

Adds an opt-in **`linkedin-outreach`** module: queue-driven, draft-first LinkedIn connection-invitation drafting.

- `draft.sh` takes the topmost person from `vault/LinkedIn Outreach Queue.md`, applies a **hook-gated decision** (genuine hook -> one honest line; no hook -> clean bare invite), and writes a review card to `reports/linkedin-outreach/cards/`.
- `record.sh` logs the outcome (sent / rejected / skipped), moves the queue line, and archives the card.
- `install.sh` optionally schedules a weekday-08:00 draft (launchd on macOS, cron on Linux).

## Design

- **Draft-first, manual send.** The module does the judgment and the writing; the user clicks Connect themselves. LinkedIn's ToS restricts session automation, so the kit ships no auto-send and no scraper dependency (same posture as the `whatsapp` module). An optional "wire your own LinkedIn MCP" path is documented for power users.
- **No credentials, no external services.** Works purely from the queue line's context note.
- **One card at a time + daily cap** (default 5) so the queue drains at a human pace.
- Follows the kit/user-data split: tracked files are placeholder-free; the queue lives in git-ignored `vault/`.

## Touches

New `modules/linkedin-outreach/` (README, `draft.sh`, `record.sh`, `install.sh`, `_outreach.py`, `prompts/draft-note.md`, `queue.example.md`). Doc updates: both module tables, `config/user.config.yaml.template`, `.env.example`.

## Tested

Preflight gating (fresh repo, empty queue, open-card block, daily cap), the record/queue-move flow, and the generated launchd plist (`plutil -lint` OK). Bash scripts syntax-checked under macOS `/bin/bash` 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)