### PR TITLE
feat: add document-export skill (PDF, Excel, Word)

### DIFF
--- a/.claude/skills/document-export/SKILL.md
+++ b/.claude/skills/document-export/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: document-export
+description: Create a PDF, Excel (.xlsx), or Word (.docx) file from content. Use for "/document-export", "make a PDF", "export to Excel", "put this in a spreadsheet", "save this as a Word doc", or when the user needs a shareable office document rather than a note or a raw HTML page.
+---
+
+# Document Export
+
+Turn content into a real office file: a **PDF**, an **Excel workbook**, or a
+**Word document**. The skill ships three helper scripts that do the file writing
+deterministically; your job is to assemble the content and call the right one.
+
+These scripts use the Python standard library only, so there is nothing to
+install for Excel and Word. PDF needs a browser or a PDF tool on the machine
+(the script finds it, or tells the user what to install).
+
+Save every output to `reports/` as `YYYY-MM-DD-<slug>.<ext>`, then tell the user
+the path.
+
+## PDF
+
+PDF is produced by rendering an HTML file. Two cases:
+
+- **Rich, visual page** (architecture, dashboard, comparison): use the
+  `visual-explainer` skill to build the HTML, then convert it.
+- **Plain document** (a letter, a report, a write-up): wrap the content in this
+  minimal template and save it as an `.html` file:
+
+```html
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>TITLE</title>
+<style>
+  @page { margin: 2cm; }
+  body { font: 11pt/1.55 -apple-system, "Segoe UI", Roboto, sans-serif;
+         color: #1a1a1a; max-width: 46em; margin: 0 auto; }
+  h1, h2, h3 { line-height: 1.25; }
+  h1 { font-size: 1.8em; } h2 { font-size: 1.35em; margin-top: 1.6em; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border: 1px solid #ccc; padding: 6px 10px; text-align: left; }
+  code { background: #f4f4f4; padding: 1px 4px; border-radius: 3px; }
+</style></head><body>
+  <!-- CONTENT -->
+</body></html>
+```
+
+Then convert:
+
+```bash
+python3 .claude/skills/document-export/to_pdf.py <input.html> reports/<YYYY-MM-DD>-<slug>.pdf
+```
+
+It tries headless Chrome first, then weasyprint, then wkhtmltopdf. If it reports
+that no engine is found, relay its install hint to the user; do not try to work
+around it.
+
+## Excel (.xlsx)
+
+Build a JSON spec, write it to a temporary file, and run the writer.
+
+Spec shape:
+
+```json
+{
+  "sheets": [
+    {
+      "name": "Results",
+      "header": true,
+      "rows": [["Name", "Score"], ["Alice", 90], ["Bob", 85]],
+      "widths": [24, 10]
+    }
+  ]
+}
+```
+
+- `header: true` bolds the first row. `widths` (column widths in characters) is
+  optional. Multiple sheets are allowed.
+- Cell values may be strings, numbers, booleans, or `null` (an empty cell).
+  Keep numbers as numbers in the JSON so Excel treats them as numeric.
+
+Run it:
+
+```bash
+python3 .claude/skills/document-export/to_xlsx.py /tmp/export-spec.json reports/<YYYY-MM-DD>-<slug>.xlsx
+```
+
+You can also pipe the spec on stdin by passing `-` instead of a file path.
+
+## Word (.docx)
+
+Build a JSON spec of blocks, then run the writer.
+
+Spec shape:
+
+```json
+{
+  "title": "Optional document title",
+  "blocks": [
+    {"type": "heading", "level": 2, "text": "A section"},
+    {"type": "paragraph", "text": "A plain paragraph."},
+    {"type": "paragraph", "runs": [
+      {"text": "mixed ", "bold": true},
+      {"text": "formatting", "italic": true}
+    ]},
+    {"type": "bullets",  "items": ["first point", "second point"]},
+    {"type": "numbered", "items": ["step one", "step two"]},
+    {"type": "table", "header": true, "rows": [["Col A", "Col B"], ["1", "2"]]}
+  ]
+}
+```
+
+- `heading` levels are 1 to 3. A `paragraph` carries plain `text` (with optional
+  `bold` / `italic` for the whole paragraph) or a list of `runs` for mixed
+  formatting. `table` rows are lists of cell strings; `header: true` bolds the
+  first row.
+
+Run it:
+
+```bash
+python3 .claude/skills/document-export/to_docx.py /tmp/export-spec.json reports/<YYYY-MM-DD>-<slug>.docx
+```
+
+## After exporting
+
+- Delete any temporary spec file you created.
+- Give the user the exact path of the file.
+- If the user wants to share the file, that is an outward action: hand it over,
+  do not send it anywhere yourself.
+
+## Scope
+
+These writers cover the structure that carries content: values, headings,
+formatting, lists, simple tables, column widths. They do not do Excel formulas,
+charts, or merged cells, or Word images, footnotes, or page headers. If a
+request needs those, say so and either extend the script or, if the user has the
+`openpyxl` or `python-docx` library available, write a one-off script with it
+instead.

--- a/.claude/skills/document-export/to_docx.py
+++ b/.claude/skills/document-export/to_docx.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Compabob document-export: build a .docx document from a JSON spec.
+
+Standard library only. No python-docx. It hand-writes a minimal but valid Office
+Open XML word-processing document that opens in Word, Pages, and LibreOffice.
+
+  usage: python3 to_docx.py <spec.json> <output.docx>
+         python3 to_docx.py -          <output.docx>   # spec read from stdin
+
+Spec JSON:
+{
+  "title": "Optional document title",
+  "blocks": [
+    {"type": "heading", "level": 2, "text": "A section"},
+    {"type": "paragraph", "text": "A plain paragraph."},
+    {"type": "paragraph", "runs": [
+        {"text": "mixed ", "bold": true},
+        {"text": "formatting", "italic": true}
+    ]},
+    {"type": "bullets",  "items": ["first point", "second point"]},
+    {"type": "numbered", "items": ["step one", "step two"]},
+    {"type": "table", "header": true, "rows": [["Col A","Col B"],["1","2"]]}
+  ]
+}
+
+A paragraph may carry plain "text" (with optional "bold"/"italic" for the whole
+paragraph) or a list of "runs" for mixed formatting. This writer covers titles,
+headings 1-3, paragraphs, bold/italic runs, bullet and numbered lists, and
+simple tables. It does not do images, footnotes, or page headers; extend it if
+you need those.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import zipfile
+
+XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+
+
+def esc(value: object) -> str:
+    return (
+        str(value).replace("&", "&amp;").replace("<", "&lt;")
+        .replace(">", "&gt;").replace('"', "&quot;")
+    )
+
+
+def run_xml(text: str, bold: bool = False, italic: bool = False) -> str:
+    rpr = ""
+    if bold or italic:
+        rpr = "<w:rPr>" + ("<w:b/>" if bold else "") + ("<w:i/>" if italic else "") + "</w:rPr>"
+    return f'<w:r>{rpr}<w:t xml:space="preserve">{esc(text)}</w:t></w:r>'
+
+
+def para(runs: str, style: str | None = None, num_id: int | None = None) -> str:
+    inner = ""
+    if style:
+        inner += f'<w:pStyle w:val="{style}"/>'
+    if num_id:
+        inner += f'<w:numPr><w:ilvl w:val="0"/><w:numId w:val="{num_id}"/></w:numPr>'
+    ppr = f"<w:pPr>{inner}</w:pPr>" if inner else ""
+    return f"<w:p>{ppr}{runs}</w:p>"
+
+
+def table_xml(rows: list, header: bool) -> str:
+    sides = ("top", "left", "bottom", "right", "insideH", "insideV")
+    borders = "<w:tblBorders>" + "".join(
+        f'<w:{s} w:val="single" w:sz="4" w:space="0" w:color="999999"/>'
+        for s in sides
+    ) + "</w:tblBorders>"
+    tbl_pr = f'<w:tblPr><w:tblW w:w="0" w:type="auto"/>{borders}</w:tblPr>'
+    trs = []
+    for r_index, row in enumerate(rows):
+        bold = header and r_index == 0
+        cells = "".join(
+            '<w:tc><w:tcPr><w:tcW w:w="0" w:type="auto"/></w:tcPr>'
+            + para(run_xml("" if cell is None else cell, bold=bold))
+            + "</w:tc>"
+            for cell in row
+        )
+        trs.append(f"<w:tr>{cells}</w:tr>")
+    return f"<w:tbl>{tbl_pr}" + "".join(trs) + "</w:tbl>"
+
+
+def block_xml(block: dict) -> str:
+    kind = (block.get("type") or "paragraph").lower()
+
+    if kind == "heading":
+        level = block.get("level", 1)
+        level = level if level in (1, 2, 3) else 1
+        return para(run_xml(block.get("text", "")), style=f"Heading{level}")
+
+    if kind == "paragraph":
+        runs = block.get("runs")
+        if runs:
+            joined = "".join(
+                run_xml(r.get("text", ""), r.get("bold", False), r.get("italic", False))
+                for r in runs
+            )
+            return para(joined)
+        return para(run_xml(
+            block.get("text", ""),
+            block.get("bold", False),
+            block.get("italic", False),
+        ))
+
+    if kind == "bullets":
+        return "".join(
+            para(run_xml(item), style="ListParagraph", num_id=1)
+            for item in block.get("items", [])
+        )
+
+    if kind == "numbered":
+        return "".join(
+            para(run_xml(item), style="ListParagraph", num_id=2)
+            for item in block.get("items", [])
+        )
+
+    if kind == "table":
+        return table_xml(block.get("rows", []), bool(block.get("header", False))) + "<w:p/>"
+
+    # Unknown block type: render its text as a plain paragraph so nothing is lost.
+    return para(run_xml(block.get("text", "")))
+
+
+SECT_PR = (
+    '<w:sectPr><w:pgSz w:w="11906" w:h="16838"/>'
+    '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>'
+)
+
+STYLES_XML = XML_DECL + (
+    f'<w:styles xmlns:w="{W}">'
+    '<w:docDefaults><w:rPrDefault><w:rPr>'
+    '<w:rFonts w:ascii="Calibri" w:hAnsi="Calibri"/><w:sz w:val="22"/>'
+    '</w:rPr></w:rPrDefault>'
+    '<w:pPrDefault><w:pPr>'
+    '<w:spacing w:after="120" w:line="276" w:lineRule="auto"/>'
+    '</w:pPr></w:pPrDefault></w:docDefaults>'
+    '<w:style w:type="paragraph" w:default="1" w:styleId="Normal">'
+    '<w:name w:val="Normal"/></w:style>'
+    '<w:style w:type="paragraph" w:styleId="Title">'
+    '<w:name w:val="Title"/><w:basedOn w:val="Normal"/>'
+    '<w:pPr><w:spacing w:after="240"/></w:pPr>'
+    '<w:rPr><w:b/><w:sz w:val="56"/></w:rPr></w:style>'
+    '<w:style w:type="paragraph" w:styleId="Heading1">'
+    '<w:name w:val="heading 1"/><w:basedOn w:val="Normal"/>'
+    '<w:pPr><w:keepNext/><w:spacing w:before="240" w:after="120"/>'
+    '<w:outlineLvl w:val="0"/></w:pPr>'
+    '<w:rPr><w:b/><w:sz w:val="32"/></w:rPr></w:style>'
+    '<w:style w:type="paragraph" w:styleId="Heading2">'
+    '<w:name w:val="heading 2"/><w:basedOn w:val="Normal"/>'
+    '<w:pPr><w:keepNext/><w:spacing w:before="200" w:after="100"/>'
+    '<w:outlineLvl w:val="1"/></w:pPr>'
+    '<w:rPr><w:b/><w:sz w:val="28"/></w:rPr></w:style>'
+    '<w:style w:type="paragraph" w:styleId="Heading3">'
+    '<w:name w:val="heading 3"/><w:basedOn w:val="Normal"/>'
+    '<w:pPr><w:keepNext/><w:spacing w:before="160" w:after="80"/>'
+    '<w:outlineLvl w:val="2"/></w:pPr>'
+    '<w:rPr><w:b/><w:sz w:val="24"/></w:rPr></w:style>'
+    '<w:style w:type="paragraph" w:styleId="ListParagraph">'
+    '<w:name w:val="List Paragraph"/><w:basedOn w:val="Normal"/>'
+    '<w:pPr><w:ind w:left="720"/></w:pPr></w:style>'
+    '</w:styles>'
+)
+
+NUMBERING_XML = XML_DECL + (
+    f'<w:numbering xmlns:w="{W}">'
+    '<w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">'
+    '<w:numFmt w:val="bullet"/><w:lvlText w:val="&#8226;"/>'
+    '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum>'
+    '<w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0">'
+    '<w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/>'
+    '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum>'
+    '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>'
+    '<w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>'
+    '</w:numbering>'
+)
+
+CONTENT_TYPES = XML_DECL + (
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+    '<Default Extension="xml" ContentType="application/xml"/>'
+    '<Override PartName="/word/document.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
+    '<Override PartName="/word/styles.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>'
+    '<Override PartName="/word/numbering.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>'
+    '</Types>'
+)
+
+PACKAGE_RELS = XML_DECL + (
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+    'Target="word/document.xml"/></Relationships>'
+)
+
+DOCUMENT_RELS = XML_DECL + (
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" '
+    'Target="styles.xml"/>'
+    '<Relationship Id="rId2" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" '
+    'Target="numbering.xml"/></Relationships>'
+)
+
+
+def build(spec: dict, output: str) -> None:
+    parts = []
+    title = spec.get("title")
+    if title:
+        parts.append(para(run_xml(title), style="Title"))
+    for block in spec.get("blocks", []) or []:
+        parts.append(block_xml(block))
+    if not parts:
+        parts.append(para(run_xml("")))
+
+    document = XML_DECL + (
+        f'<w:document xmlns:w="{W}"><w:body>'
+        + "".join(parts) + SECT_PR
+        + "</w:body></w:document>"
+    )
+
+    parent = os.path.dirname(os.path.abspath(output))
+    os.makedirs(parent, exist_ok=True)
+
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", CONTENT_TYPES)
+        zf.writestr("_rels/.rels", PACKAGE_RELS)
+        zf.writestr("word/document.xml", document)
+        zf.writestr("word/_rels/document.xml.rels", DOCUMENT_RELS)
+        zf.writestr("word/styles.xml", STYLES_XML)
+        zf.writestr("word/numbering.xml", NUMBERING_XML)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: to_docx.py <spec.json|-> <output.docx>", file=sys.stderr)
+        return 2
+    spec_arg, output = sys.argv[1], sys.argv[2]
+    try:
+        raw = sys.stdin.read() if spec_arg == "-" else open(
+            spec_arg, encoding="utf-8"
+        ).read()
+        spec = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"could not read spec: {exc}", file=sys.stderr)
+        return 2
+    try:
+        build(spec, output)
+    except (ValueError, TypeError, KeyError) as exc:
+        print(f"could not build document: {exc}", file=sys.stderr)
+        return 1
+    print(f"docx written: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/document-export/to_pdf.py
+++ b/.claude/skills/document-export/to_pdf.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Compabob document-export: convert a self-contained HTML file to PDF.
+
+Standard library only. It shells out to whatever HTML-to-PDF engine is on the
+machine, trying them in order of rendering fidelity:
+
+  1. headless Chrome / Chromium / Edge / Brave   (best CSS support)
+  2. weasyprint                                  (good modern CSS)
+  3. wkhtmltopdf                                 (older engine, widely packaged)
+
+If none is found it prints an install hint and exits non-zero.
+
+  usage: python3 to_pdf.py <input.html> [output.pdf]
+
+The input must be a self-contained HTML file (inline CSS, no external assets),
+which is exactly what the visual-explainer skill produces. For markdown or
+plain text, wrap it in HTML first (see SKILL.md).
+"""
+from __future__ import annotations
+
+import glob
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_chrome() -> str | None:
+    for name in (
+        "google-chrome", "google-chrome-stable", "chromium",
+        "chromium-browser", "microsoft-edge", "brave-browser",
+    ):
+        found = shutil.which(name)
+        if found:
+            return found
+    for path in (
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    ):
+        if os.path.isfile(path):
+            return path
+    # Playwright-managed Chromium (compabob's integrations module installs this).
+    for base in (
+        Path.home() / "Library" / "Caches" / "ms-playwright",
+        Path.home() / ".cache" / "ms-playwright",
+    ):
+        for pattern in (
+            "chromium-*/chrome-*/Chromium.app/Contents/MacOS/Chromium",
+            "chromium-*/chrome-linux/chrome",
+            "chromium_headless_shell-*/chrome-*/headless_shell",
+        ):
+            hits = sorted(glob.glob(str(base / pattern)))
+            if hits:
+                return hits[-1]
+    return None
+
+
+def via_chrome(chrome: str, html_path: str, pdf_path: str) -> bool:
+    url = Path(html_path).resolve().as_uri()
+    out = os.path.abspath(pdf_path)
+    base = [chrome, "--headless", "--disable-gpu", "--no-sandbox"]
+    # Newer Chrome accepts --no-pdf-header-footer; older ignores or rejects it,
+    # so fall back to a plain run.
+    for extra in (["--no-pdf-header-footer"], []):
+        try:
+            result = subprocess.run(
+                base + extra + [f"--print-to-pdf={out}", url],
+                capture_output=True, text=True, timeout=120,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+        if result.returncode == 0 and os.path.isfile(out):
+            return True
+    return False
+
+
+def via_tool(tool: str, args: list[str]) -> bool:
+    binary = shutil.which(tool)
+    if not binary:
+        return False
+    try:
+        result = subprocess.run(
+            [binary, *args], capture_output=True, text=True, timeout=120,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: to_pdf.py <input.html> [output.pdf]", file=sys.stderr)
+        return 2
+
+    html_path = sys.argv[1]
+    if not os.path.isfile(html_path):
+        print(f"input not found: {html_path}", file=sys.stderr)
+        return 2
+    if not html_path.lower().endswith((".html", ".htm")):
+        print(
+            "input must be an .html file. For markdown or plain text, wrap it "
+            "in HTML first (see SKILL.md).",
+            file=sys.stderr,
+        )
+        return 2
+
+    pdf_path = (
+        sys.argv[2] if len(sys.argv) > 2
+        else os.path.splitext(html_path)[0] + ".pdf"
+    )
+    parent = os.path.dirname(os.path.abspath(pdf_path))
+    os.makedirs(parent, exist_ok=True)
+
+    in_abs = os.path.abspath(html_path)
+    out_abs = os.path.abspath(pdf_path)
+
+    chrome = find_chrome()
+    if chrome and via_chrome(chrome, html_path, pdf_path):
+        print(f"PDF written via Chrome: {pdf_path}")
+        return 0
+    if via_tool("weasyprint", [in_abs, out_abs]) and os.path.isfile(out_abs):
+        print(f"PDF written via weasyprint: {pdf_path}")
+        return 0
+    if via_tool("wkhtmltopdf", ["--quiet", in_abs, out_abs]) and os.path.isfile(out_abs):
+        print(f"PDF written via wkhtmltopdf: {pdf_path}")
+        return 0
+
+    print(
+        "No HTML-to-PDF engine found. Install one of these, then retry:\n"
+        "  - Google Chrome   https://www.google.com/chrome/  (best fidelity, nothing else to do)\n"
+        "  - weasyprint      macOS: brew install weasyprint    Linux: pipx install weasyprint\n"
+        "  - wkhtmltopdf     macOS: brew install wkhtmltopdf   Linux: sudo apt install wkhtmltopdf",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/document-export/to_xlsx.py
+++ b/.claude/skills/document-export/to_xlsx.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Compabob document-export: build a .xlsx workbook from a JSON spec.
+
+Standard library only. No openpyxl, no pandas. It hand-writes a minimal but
+valid Office Open XML spreadsheet that opens in Excel, Numbers, and LibreOffice.
+
+  usage: python3 to_xlsx.py <spec.json> <output.xlsx>
+         python3 to_xlsx.py -          <output.xlsx>   # spec read from stdin
+
+Spec JSON:
+{
+  "sheets": [
+    {
+      "name": "Results",
+      "header": true,                       # bold the first row (optional)
+      "rows": [["Name", "Score"], ["Alice", 90], ["Bob", 85]],
+      "widths": [24, 10]                    # column widths, chars (optional)
+    }
+  ]
+}
+
+Cell values may be strings, numbers (int/float), booleans, or null (an empty
+cell). This writer covers values, a bold header row, and column widths. It does
+not do formulas, charts, merged cells, or themes; extend it if you need those.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import zipfile
+
+XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+
+
+def esc(value: object) -> str:
+    return (
+        str(value).replace("&", "&amp;").replace("<", "&lt;")
+        .replace(">", "&gt;").replace('"', "&quot;")
+    )
+
+
+def col_letter(index: int) -> str:
+    """1 -> A, 26 -> Z, 27 -> AA."""
+    letters = ""
+    while index > 0:
+        index, remainder = divmod(index - 1, 26)
+        letters = chr(65 + remainder) + letters
+    return letters
+
+
+def cell_xml(ref: str, value: object, bold: bool) -> str:
+    style = ' s="1"' if bold else ""
+    if value is None or value == "":
+        return f'<c r="{ref}"{style}/>'
+    if isinstance(value, bool):
+        return f'<c r="{ref}"{style} t="b"><v>{1 if value else 0}</v></c>'
+    if isinstance(value, (int, float)):
+        return f'<c r="{ref}"{style}><v>{value}</v></c>'
+    return (
+        f'<c r="{ref}"{style} t="inlineStr">'
+        f'<is><t xml:space="preserve">{esc(value)}</t></is></c>'
+    )
+
+
+def sheet_xml(sheet: dict) -> str:
+    rows = sheet.get("rows", []) or []
+    header = bool(sheet.get("header", False))
+    widths = sheet.get("widths") or []
+
+    cols = ""
+    col_parts = [
+        f'<col min="{i}" max="{i}" width="{w}" customWidth="1"/>'
+        for i, w in enumerate(widths, start=1) if w
+    ]
+    if col_parts:
+        cols = "<cols>" + "".join(col_parts) + "</cols>"
+
+    body = []
+    for r_index, row in enumerate(rows, start=1):
+        bold = header and r_index == 1
+        cells = "".join(
+            cell_xml(f"{col_letter(c_index)}{r_index}", value, bold)
+            for c_index, value in enumerate(row, start=1)
+        )
+        body.append(f'<row r="{r_index}">{cells}</row>')
+
+    return (
+        XML_DECL
+        + '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        + cols
+        + "<sheetData>" + "".join(body) + "</sheetData>"
+        + "</worksheet>"
+    )
+
+
+STYLES_XML = XML_DECL + (
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+    '<fonts count="2">'
+    '<font><sz val="11"/><name val="Calibri"/></font>'
+    '<font><b/><sz val="11"/><name val="Calibri"/></font>'
+    '</fonts>'
+    '<fills count="2">'
+    '<fill><patternFill patternType="none"/></fill>'
+    '<fill><patternFill patternType="gray125"/></fill>'
+    '</fills>'
+    '<borders count="1"><border/></borders>'
+    '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>'
+    '<cellXfs count="2">'
+    '<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>'
+    '<xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>'
+    '</cellXfs>'
+    '</styleSheet>'
+)
+
+RELS_XML = XML_DECL + (
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+    'Target="xl/workbook.xml"/>'
+    '</Relationships>'
+)
+
+
+def build(spec: dict, output: str) -> None:
+    sheets = spec.get("sheets") or []
+    if not sheets:
+        raise ValueError("spec needs at least one entry in 'sheets'.")
+
+    count = len(sheets)
+    content_types = [
+        XML_DECL,
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">',
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>',
+        '<Default Extension="xml" ContentType="application/xml"/>',
+        '<Override PartName="/xl/workbook.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>',
+        '<Override PartName="/xl/styles.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>',
+    ]
+    for i in range(1, count + 1):
+        content_types.append(
+            f'<Override PartName="/xl/worksheets/sheet{i}.xml" '
+            'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
+        )
+    content_types.append("</Types>")
+
+    sheet_tags = "".join(
+        f'<sheet name="{esc(sheet.get("name") or f"Sheet{i}")}" '
+        f'sheetId="{i}" r:id="rId{i}"/>'
+        for i, sheet in enumerate(sheets, start=1)
+    )
+    workbook = XML_DECL + (
+        '<workbook '
+        'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+        'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+        f"<sheets>{sheet_tags}</sheets></workbook>"
+    )
+
+    rel_tags = "".join(
+        f'<Relationship Id="rId{i}" '
+        'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" '
+        f'Target="worksheets/sheet{i}.xml"/>'
+        for i in range(1, count + 1)
+    )
+    rel_tags += (
+        f'<Relationship Id="rId{count + 1}" '
+        'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" '
+        'Target="styles.xml"/>'
+    )
+    workbook_rels = XML_DECL + (
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        + rel_tags + "</Relationships>"
+    )
+
+    parent = os.path.dirname(os.path.abspath(output))
+    os.makedirs(parent, exist_ok=True)
+
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", "".join(content_types))
+        zf.writestr("_rels/.rels", RELS_XML)
+        zf.writestr("xl/workbook.xml", workbook)
+        zf.writestr("xl/_rels/workbook.xml.rels", workbook_rels)
+        zf.writestr("xl/styles.xml", STYLES_XML)
+        for i, sheet in enumerate(sheets, start=1):
+            zf.writestr(f"xl/worksheets/sheet{i}.xml", sheet_xml(sheet))
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: to_xlsx.py <spec.json|-> <output.xlsx>", file=sys.stderr)
+        return 2
+    spec_arg, output = sys.argv[1], sys.argv[2]
+    try:
+        raw = sys.stdin.read() if spec_arg == "-" else open(
+            spec_arg, encoding="utf-8"
+        ).read()
+        spec = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"could not read spec: {exc}", file=sys.stderr)
+        return 2
+    try:
+        build(spec, output)
+    except (ValueError, TypeError, KeyError) as exc:
+        print(f"could not build workbook: {exc}", file=sys.stderr)
+        return 1
+    print(f"xlsx written: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills are slash-command workflows. Type the command; the assistant runs the pro
 | `/add-agent` | Scaffold a new specialized agent interactively |
 | `/system-audit` | Health-check the assistant's own setup |
 | `/visual-explainer` | Turn a system, plan, or dataset into a self-contained HTML page |
+| `/document-export` | Create a PDF, Excel, or Word file from your content |
 
 ## Modules (opt-in)
 


### PR DESCRIPTION
## What

Adds a **`/document-export`** skill that turns content into a real office file: a PDF, an Excel workbook, or a Word document. The skill ships three deterministic helper scripts.

| Format | Script | Approach |
|--------|--------|----------|
| PDF | `to_pdf.py` | Renders an HTML file. Autodetects headless Chrome, then weasyprint, then wkhtmltopdf. Composes with the `visual-explainer` skill. |
| Excel `.xlsx` | `to_xlsx.py` | Hand-writes valid Office Open XML from a JSON spec: sheets, rows, bold header, column widths. |
| Word `.docx` | `to_docx.py` | Hand-writes valid Office Open XML from a JSON spec: title, headings, bold/italic runs, bullet + numbered lists, tables. |

## Design

- **Stdlib only.** No `openpyxl`, no `python-docx`, no `pip install`. The xlsx/docx writers build the OOXML zip by hand with `zipfile`, so the skill works on a fresh clone with nothing but `python3`, consistent with the rest of the kit (the memory-search module is stdlib-only for the same reason).
- **PDF shells out.** Rendering HTML to PDF cannot be hand-rolled, so `to_pdf.py` finds a browser/PDF engine on the machine and prints an install hint if none is present. Same pattern as memory-search talking to Ollama.
- **Scope is honest.** The writers cover structure and basic formatting, not charts, pivots, images, or footnotes. `SKILL.md` states the limit and points to a library-based fallback for advanced cases.

## Touches

New `.claude/skills/document-export/` (`SKILL.md`, `to_pdf.py`, `to_xlsx.py`, `to_docx.py`). Doc update: skills table in `README.md`.

## Tested

- xlsx + docx: every XML part well-formed, zip intact; docx opens cleanly via macOS `textutil` (proves Word can parse it).
- PDF: rendered via headless Chrome, valid `%PDF-1.4`.
- All scripts syntax-checked and `chmod +x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)