### PR TITLE
chore: CI smoke test, FUNDING.yml, fix memory-search status

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Compabob has no monetization model. If the kit saves you time and you want to
+# return the favor, a star on the repo is the most useful signal. Sharing it or
+# opening a PR is even better.
+custom: ["https://www.linkedin.com/in/philippwenger/"]

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,64 @@
+name: smoke
+
+# Weekly fresh-clone smoke test. Catches kit bit-rot before users hit it:
+# any breakage in setup.sh, init.sh, or shell scripts surfaces here, not in
+# someone's first ten minutes with the kit.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 06:00 UTC — early enough that issues land before the weekly traffic peak.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Shell syntax check (bash -n on every *.sh)
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r -d '' f; do
+            if ! bash -n "$f"; then
+              echo "::error file=$f::bash syntax error"
+              fail=1
+            fi
+          done < <(find . -path ./node_modules -prune -o -type f -name '*.sh' -print0)
+          exit "$fail"
+
+      - name: Run setup.sh non-interactively (default answers)
+        run: |
+          set -euo pipefail
+          # Six blank lines = take the default for each ask() prompt + skip
+          # the optional integrations step. Setup is idempotent and never
+          # overwrites existing files, so this is safe to re-run.
+          printf '\n\n\n\n\n\n' | ./setup.sh
+
+      - name: Run init.sh (must exit 0; warnings tolerated)
+        run: |
+          set -uo pipefail
+          # init.sh exits with the number of failures. Warnings (e.g. claude
+          # CLI not installed in CI) are expected and do not count as failures.
+          bash scripts/init.sh
+          ec=$?
+          if [ "$ec" -ne 0 ]; then
+            echo "::error::init.sh reported $ec failure(s)"
+            exit "$ec"
+          fi
+
+      - name: Validate JSON catalog
+        run: |
+          python3 -c "import json; json.load(open('scripts/integrations-catalog.json'))"
+          echo "integrations-catalog.json is valid JSON"

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The core runs with zero external services. Modules add capability when you want 
 | `telegram` | Available | A Telegram bot: inbound messages drafted for your approval, never auto-sent |
 | `integrations` | Available | MCP tools: browser automation, web search, Gmail, Calendar, utilities |
 | `linkedin-outreach` | Available | Drafts one LinkedIn connection-invitation card a day from a queue, for your review and manual send |
-| `memory-search` | Roadmap | Semantic search over your memory and vault (needs a local embedding model) |
+| `memory-search` | Available | Real index over `memory/` and `vault/` so retrieval ranks by relevance (FTS5 by default; semantic via Ollama if installed) |
 | `extra-agents` | Roadmap | An agent gallery: designer, evaluator, sales coach, project manager |
 | `whatsapp` | Roadmap | WhatsApp channel — not built (account-ban risk); use Telegram instead |
 


### PR DESCRIPTION
## Summary

Three post-launch hygiene fixes bundled into one PR. Anti-bit-rot foundation work, sequenced first because v1.0.0 (next PR) should ship with CI already green.

- **CI smoke test** (`.github/workflows/smoke.yml`): triggers on push, PR, Monday 06:00 UTC cron, and manual dispatch. Runs `bash -n` on every `*.sh`, executes `./setup.sh` non-interactively (default answers), runs `scripts/init.sh` (must exit 0), and validates `scripts/integrations-catalog.json`. First win: this PR will itself verify the workflow runs green.
- **FUNDING.yml**: `custom: ["https://www.linkedin.com/in/philippwenger/"]` — surfaces a Sponsor button (no Sponsors listing on the account). Reads as a visible maintenance signal more than a real funding ask.
- **memory-search drift fix**: the README modules table said "Roadmap" but `modules/memory-search/README.md:1` ships it as **available**. Fixed the row and rewrote the description to match what actually ships (FTS5 by default, Ollama semantic mode opt-in).

## Test plan

- [ ] CI smoke job runs green on this PR.
- [ ] After merge, GitHub renders the Sponsor button in the sidebar.
- [ ] README modules table no longer claims memory-search is Roadmap.
- [x] Local fresh-clone smoke test: ran `git clone ~/compabob /tmp/test && printf '\n\n\n\n\n\n' | ./setup.sh && bash scripts/init.sh` — all checks pass, exit 0.

Part of the post-launch improvement plan (1/3 of the anti-bit-rot vector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)