### PR TITLE
docs: badges, alternatives section, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to Compabob are recorded here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows
+[SemVer](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- `.github/workflows/smoke.yml` — weekly fresh-clone CI smoke test
+  (push, PR, Monday 06:00 UTC, manual). Runs `bash -n` on every shell
+  script, executes `setup.sh` non-interactively, then `init.sh`, then
+  validates the integrations catalog JSON.
+- `.github/FUNDING.yml` — surfaces a Sponsor button (LinkedIn, no
+  Sponsors listing); a maintenance signal more than a funding ask.
+- README badges row: CI, License, Stars, Last commit.
+- README section "How this differs from the other Claude Code things
+  you have seen" — short comparison vs. raw Claude Code, awesome lists,
+  multi-agent dev-team frameworks, and DIY.
+
+### Fixed
+
+- README modules table claimed `memory-search` was Roadmap; the module
+  ships as available. Row rewritten to match `modules/memory-search/README.md`.
+
+## [1.0.0] — 2026-05-20
+
+Initial public release at [github.com/chacosoldier/compabob](https://github.com/chacosoldier/compabob).
+
+### Core
+
+- `CONSTITUTION.md` — the rules every session loads.
+- `CLAUDE.md` — project entry point.
+- `.claude/agents/` — 8 specialized agents: `daily-copilot`,
+  `second-brain`, `analyst`, `crm-relationships`, `comms-meetings`,
+  `strategy-advisor`, `principal-engineer`, `first-principles`.
+- `.claude/skills/` — slash-command workflows: `/morning-brief`,
+  `/meeting-prep`, `/post-call`, `/handover`, `/log-decision`, `/tasks`,
+  `/reflect`, `/index-memory`, `/add-agent`, `/system-audit`,
+  `/visual-explainer`, `/document-export`.
+- `.claude/output-styles/` — the answer-first response style.
+- `hooks/` — safety guards (prompt-injection defender, etc.) and
+  lifecycle automation.
+
+### User-data layer
+
+- `vault.example/`, `memory.example/`, `config/user.config.yaml.template`,
+  `.claude/settings.local.json.template` — seeds that `setup.sh` copies
+  into git-ignored `vault/`, `memory/`, `config/` on first run. Updates
+  via `./update.sh` cannot touch user data.
+- Five persona presets: `generalist`, `consultant`, `engineer`, `sales`,
+  `founder` (under `config/personas/`).
+
+### Modules
+
+- `proactive` (available) — scheduled morning brief + weekly review.
+- `telegram` (available) — Telegram bot that drafts inbound messages
+  for approval; never auto-sends.
+- `integrations` (available) — MCP servers via a pinned catalog at
+  `scripts/integrations-catalog.json`.
+- `linkedin-outreach` (available, added day 1 via PR #1) — one
+  invitation card per day from a queue, manual send.
+- `memory-search` (available) — keyword (FTS5) index by default,
+  semantic via Ollama embeddings if installed.
+- `extra-agents` (planned), `team` (deferred), `whatsapp` (won't build).
+
+### Tooling
+
+- `setup.sh` — interactive first-run, idempotent, never overwrites.
+- `update.sh` — pulls latest, preserves user data.
+- `scripts/init.sh` — per-session health check.
+- `scripts/install-integrations.sh` — MCP picker.
+
+### Day-1 PRs merged
+
+- #1 `linkedin-outreach` module.
+- #2 `/document-export` skill (PDF, Excel, Word).
+- #3 Community health files + social preview image.
+
+### Docs
+
+- `docs/architecture.md`, `docs/onboarding.md`, `docs/customization-guide.md`,
+  `docs/how-to-improve-memory.md`.
+
+[Unreleased]: https://github.com/chacosoldier/compabob/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/chacosoldier/compabob/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Compabob
 
+[![CI](https://github.com/chacosoldier/compabob/actions/workflows/smoke.yml/badge.svg)](https://github.com/chacosoldier/compabob/actions/workflows/smoke.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/chacosoldier/compabob?style=social)](https://github.com/chacosoldier/compabob/stargazers)
+[![Last commit](https://img.shields.io/github/last-commit/chacosoldier/compabob)](https://github.com/chacosoldier/compabob/commits/main)
+
 **A customizable [Claude Code](https://docs.anthropic.com/en/docs/claude-code) setup for knowledge workers.** Clone it, run `./setup.sh`, name your assistant, and in about ten minutes you have a working AI work partner: it knows your role, remembers what you tell it, routes work to specialized agents, and never sends anything without your sign-off.
 
 ## Why
@@ -16,6 +21,13 @@ That second-brain loop is the value you get immediately. Compabob is scaffolding
 
 - **Is**: an opinionated, single-user template. Architecture, conventions, and a set of agents/hooks/skills that took real iteration to get right, packaged so you do not start from zero.
 - **Is not**: a product, a SaaS, or a no-config magic box. There is no signup, no telemetry, no upsell. It runs entirely on your machine under your own Claude Code subscription.
+
+## How this differs from the other Claude Code things you have seen
+
+- **vs. raw Claude Code.** Claude Code is the harness. Compabob is the opinionated scaffolding on top: a constitution, an agent fleet, safety hooks, a memory system, and a knowledge base, all wired together. Without that scaffolding, every new session starts from zero.
+- **vs. "awesome" lists** (curated link directories). Those tell you what exists. Compabob is a working kit you clone and run.
+- **vs. multi-agent dev-team frameworks.** Frameworks oriented at orchestrating software-engineering crews assume you are building software with AI. Compabob is built for a single knowledge worker doing their actual job: meetings, notes, research, comms, decisions.
+- **vs. building your own from scratch.** That is the alternative most people pick, and most never finish. The structure here took real iteration; you skip that part.
 
 ## Maintenance posture
 


### PR DESCRIPTION
## Summary

Star-conversion + maintenance-signal work, sequenced after #5 (CI + memory-search drift fix). No conflicts with #5.

- **README badges row** (CI, License, Stars, Last commit). The 21% star rate on launch traffic suggests visitors clone but never star — badges add the "real project" social proof signal that flat READMEs lack.
- **New "How this differs" section** after "What this is (and is not)". Four short comparison bullets vs raw Claude Code, awesome lists, multi-agent dev-team frameworks, and DIY. Anchors search intent for visitors arriving from "claude code template" / "claude code starter" Google queries.
- **CHANGELOG.md** in Keep-a-Changelog format. v1.0.0 entry = launch state. [Unreleased] section already captures this PR + #5. Sets the cadence; v1.1.0 cut comes after both PRs merge.

## Test plan

- [ ] README renders the four badges in GitHub's preview after merge.
- [ ] "How this differs" section reads as factual, not snarky, on re-read.
- [ ] CHANGELOG's `[1.0.0]` link will resolve once the v1.0.0 tag is cut (next PR).
- [ ] CI smoke job (added in #5) runs green on this PR.

Stacked behind #5 (no conflicts). After both merge → tag v1.0.0 → cut a v1.1.0 entry for these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)