### PR TITLE
docs: add Linux troubleshooting subsection to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Run `bash scripts/init.sh`. It checks your setup and tells you, in plain languag
 ### Linux and Windows
 
 - **Linux**: skip Homebrew. Install the tools with your package manager, for example `sudo apt install git nodejs npm python3`, then do steps 4 to 7.
+
+### If something looks wrong on Linux
+
+- **WSL**: `node` is sometimes split as `nodejs` + `npm`; the symlink trick (`sudo ln -s /usr/bin/nodejs /usr/local/bin/node`) if scripts expect `node`.
+- **Fedora / RHEL**: `sudo dnf install git nodejs python3` (not `python`).
+- **Arch**: `sudo pacman -S git nodejs npm python` works as-is.
+- **`python3` vs `python`**: confirming `python3 --version` returns 3.10+ before running `./setup.sh`.
+- **Permissions**: if `./setup.sh` says "Permission denied," run `chmod +x setup.sh` first.
 - **Windows**: install [WSL](https://learn.microsoft.com/windows/wsl/install) first (in PowerShell: `wsl --install`, then restart). Open the Ubuntu terminal it gives you and follow the Linux steps. Native Windows (PowerShell/cmd) is not supported.
 
 ## Updating


### PR DESCRIPTION
Closes #11

Adds a troubleshooting sub-block with 5 common Linux pitfalls (WSL, Fedora, Arch, python3 vs python, permissions).