### PR TITLE
docs: add guide for swapping default Claude model

### DIFF
--- a/.claude/skills/weekly-review/SKILL.md
+++ b/.claude/skills/weekly-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: weekly-review
+description: End-of-week review — what got done, what slipped, decisions made, and next week's top 3 priorities. Use for "/weekly-review", "end-of-week review", "what happened this week", or on the last working day of the week.
+---
+
+# Weekly Review
+
+Produce a terse end-of-week summary that captures what changed and what is still owed.
+
+## Steps
+
+1. **Determine the Week.** Confirm the ISO week (e.g. `2026-W21`). Use `date` or the `inject-now` hook.
+
+2. **Gather inputs.** Read:
+   - `vault/Daily/` — all daily notes from Monday through today (or the last 7 days). Pull `## Priorities`, `## Completed`, and any `## Reflection` sections.
+   - `vault/Decisions/` — any decision records dated this week.
+   - `memory/topics/` — entries modified this week (check `memory/MEMORY.md` for the index).
+   - If meeting notes exist in `vault/`, scan recent ones for open action items.
+
+3. **Synthesize five sections:**
+
+   - **Done** — what was completed (shipped, merged, decided, closed).
+   - **Slipped** — what was planned but not done; carry-forward items.
+   - **Decisions** — key decisions made (link to `vault/Decisions/` files).
+   - **Owed to others** — commitments the user owes to someone else.
+   - **Owed to self** — commitments the user made to themselves.
+
+4. **Propose top 3 priorities for next week.** Base them on the slip-list and the most consequential pending commitments. One sentence each.
+
+5. **Write to vault** (optional). Ask the user; if they approve, write to `vault/Weekly/YYYY-WW.md`.
+
+## Output
+
+Lead with one sentence summarising the week. Then:
+
+```
+## Weekly Review — YYYY-WW
+
+**Done**
+- ...
+
+**Slipped**
+- ...
+
+**Decisions**
+- ...
+
+**Owed to others**
+- ...
+
+**Owed to self**
+- ...
+
+### Next week's top 3
+1. ...
+2. ...
+3. ...
+```
+
+Terse and scannable. Omit any empty section. End with no closing line.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Compabob
 
+[English](README.md) | [Español](docs/i18n/README.es.md)
+
 **A customizable [Claude Code](https://docs.anthropic.com/en/docs/claude-code) setup for knowledge workers.** Clone it, run `./setup.sh`, name your assistant, and in about ten minutes you have a working AI work partner: it knows your role, remembers what you tell it, routes work to specialized agents, and never sends anything without your sign-off.
 
 ## Why
@@ -119,6 +121,7 @@ Run `bash scripts/init.sh`. It checks your setup and tells you, in plain languag
 
 - **Linux**: skip Homebrew. Install the tools with your package manager, for example `sudo apt install git nodejs npm python3`, then do steps 4 to 7.
 - **Windows**: install [WSL](https://learn.microsoft.com/windows/wsl/install) first (in PowerShell: `wsl --install`, then restart). Open the Ubuntu terminal it gives you and follow the Linux steps. Native Windows (PowerShell/cmd) is not supported.
+- **Customizing the model**: see the [model switching guide](docs/changing-the-model.md) to swap the default Claude model or set per-agent models.
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Skills are slash-command workflows. Type the command; the assistant runs the pro
 | `/system-audit` | Health-check the assistant's own setup |
 | `/visual-explainer` | Turn a system, plan, or dataset into a self-contained HTML page |
 | `/document-export` | Create a PDF, Excel, or Word file from your content |
+| `/weekly-review` | End-of-week review: done, slipped, decisions, commitments, next week's top 3 |
 
 ## Modules (opt-in)
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Run `bash scripts/init.sh`. It checks your setup and tells you, in plain languag
 ./update.sh
 ```
 
-Pulls the latest version of the kit. Your `vault/`, `memory/`, and `config/` are git-ignored and are never touched by an update, so you can personalize the kit freely and still stay current. See the [customization guide](docs/customization-guide.md) for how that works.
+Pulls the latest version of the kit. Your `vault/`, `memory/`, and `config/` are git-ignored and are never touched by an update, so you can personalize the kit freely and still stay current. See the [customization guide](docs/customization-guide.md) for how that works, and the [model switching guide](docs/changing-the-model.md) for swapping Claude models.
 
 ## First hour
 

--- a/config/personas/researcher.md
+++ b/config/personas/researcher.md
@@ -1,0 +1,53 @@
+---
+id: researcher
+label: Researcher / academia
+---
+
+# Role and priorities
+
+> What you are responsible for and what you are trying to move right now. The
+> assistant reads this to tell on-strategy work from distractions. Review it
+> monthly; priorities go stale fast. This file was pre-filled from the
+> "Researcher" persona you picked at setup. Edit every bracket to fit you.
+
+## What you work on
+
+<WHAT_YOU_WORK_ON>
+
+## Role
+
+[your title, e.g. PhD Candidate / Postdoc / R&D Scientist]. You advance knowledge
+through research: designing studies, running experiments, analysing results, and
+publishing findings.
+
+## What you own
+
+- [the research question, thesis, or R&D programme you are pursuing]
+- [the literature survey and how you stay current in your field]
+- [the experiments, simulations, or studies in flight]
+- [the papers, reports, or deliverables you are drafting or revising]
+- [the data, code, or lab notebooks underpinning your work]
+
+## Priorities this quarter
+
+> Convert any deadline to an absolute date. Rank them; the order is the point.
+
+1. [the submission deadline, conference, or milestone that matters most]
+2. [the experiment or analysis that unblocks the next step]
+3. [the literature you need to review or the gap you need to close]
+
+## Explicitly not doing
+
+- [projects, collaborations, or tangents you have decided to pause — naming
+  them lets the assistant flag a scope creep risk]
+
+## Where the assistant helps most
+
+Use `second-brain` to keep notes, references, and experiment logs linked so
+nothing falls through the cracks. Bring data and figures to `analyst` to turn
+raw results into publication-ready tables and plots. Run `/morning-brief` to
+review what is due and what changed in your field. `/log-decision` records the
+methodological calls you may need to justify during peer review. Lean on
+`first-principles` when a hard research design or interpretation question needs
+structured reasoning, and `comms-meetings` for co-author correspondence and
+conference logistics. All other agents stay available.

--- a/docs/changing-the-model.md
+++ b/docs/changing-the-model.md
@@ -1,0 +1,74 @@
+# Changing the Claude Model
+
+The kit defaults to Claude Sonnet — the best all-round balance of speed, cost, and capability. You can change the model globally per session, or per agent via frontmatter.
+
+## Per-session default
+
+Two ways to set the model for an entire session:
+
+1. **Settings file** — create or edit `.claude/settings.local.json` and add:
+   ```json
+   {
+     "model": "claude-opus-4-20250514"
+   }
+   ```
+   This file is git-ignored (your data, not the kit's), so the setting persists across sessions without touching version control.
+
+2. **CLI flag** — start the session with `claude --model claude-sonnet-4-20250514` to override the file setting for that run.
+
+The precedence is: CLI flag > `settings.local.json` > the kit's `settings.json` default (Sonnet).
+
+## Per-agent model
+
+Set a model for a single agent by adding a `model:` field in its frontmatter. Open `.claude/agents/<agent>.md` and add:
+
+```yaml
+---
+description: Use for deep strategic analysis and first-principles reasoning.
+model: claude-opus-4-20250514
+---
+```
+
+When the orchestrator routes to that agent, the session model is temporarily swapped to the one specified in its frontmatter. Other agents keep using the session default.
+
+## Trade-offs
+
+| Model   | Best for                              | Cost        | Speed  |
+|---------|---------------------------------------|-------------|--------|
+| Opus    | Hard reasoning, strategy, long chains | High        | Slow   |
+| Sonnet  | Everything else                       | Moderate    | Fast   |
+| Haiku   | Cheap classification, quick routing   | Low         | Fastest|
+
+- **Opus** — use for the hardest problems: deep strategic analysis, first-principles reasoning, complex multi-step planning. The extra deliberation is worth the wait. **Warning:** Opus counts against Pro limits much faster than Sonnet.
+- **Sonnet** — the daily driver. Fast, capable, good-enost for almost everything. Stick with it unless you specifically need Opus depth or Haiku speed.
+- **Haiku** — ideal for cheap, fast classification tasks (tagging, routing, simple extraction). Not suitable for reasoning or generation.
+
+## Worked example
+
+Suppose you want your daily assistant on Sonnet (fast, cheap) but route hard strategic work to Opus.
+
+1. Leave the session default as Sonnet (no change needed — that is what the kit ships with).
+
+2. Edit `.claude/agents/strategy-advisor.md` — add `model: claude-opus-4-20250514` in the frontmatter:
+   ```yaml
+   ---
+   description: Use for competitive analysis, market positioning, and strategic planning.
+   model: claude-opus-4-20250514
+   ---
+   ```
+
+3. Edit `.claude/agents/first-principles.md` — same addition:
+   ```yaml
+   ---
+   description: Use for root-cause analysis, mental models, and first-principles reasoning.
+   model: claude-opus-4-20250514
+   ---
+   ```
+
+4. Edit `.claude/agents/daily-copilot.md` — no model field needed (it will inherit the session's Sonnet default).
+
+Now when the orchestrator routes a question to `strategy-advisor` or `first-principles`, the session briefly switches to Opus. Everything else stays on Sonnet.
+
+## Pro vs Max
+
+If you are on a **Pro** plan, be mindful that Opus draws from your usage limits much faster than Sonnet. A single Opus exchange can consume 3–5× the tokens of a comparable Sonnet exchange. On **Max**, usage-based pricing applies, so you pay per token regardless of model — but Opus tokens are priced higher. Reserve Opus for tasks where its extra depth clearly matters.

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -1,0 +1,38 @@
+# Compabob
+
+[English](../README.md) | [Español](README.es.md)
+
+## Por qué
+
+Una sesión nueva de Claude Code es una generalista competente que no sabe nada de ti. Cada vez tienes que volver a explicarle quién eres, cómo quieres las respuestas y en qué estás trabajando. No tiene noción de tus prioridades, ni barreras de seguridad sobre lo que se envía, ni un lugar donde guardar lo que aprende.
+
+Compabob es la estructura que faltaba. El ciclo fundamental, desde el primer día:
+
+> Le pides que tome notas de la reunión de planificación de hoy. Las archiva en tu base de conocimiento. La semana siguiente, antes del seguimiento, escribes `/meeting-prep` y te devuelve los asistentes, lo que se decidió y los temas pendientes, sin que tengas que buscar nada.
+
+Ese ciclo de segundo cerebro es el valor que obtienes de inmediato. Compabob es un andamio, no un asistente terminado: todo lo demás se multiplica a medida que lo haces tuyo.
+
+## Qué es (y qué no es)
+
+- **Es**: una plantilla con opinión propia para un solo usuario. Arquitectura, convenciones y un conjunto de agentes, hooks y skills que requirieron verdadera iteración para dar en el clavo, empaquetados para que no empieces desde cero.
+- **No es**: un producto, un SaaS ni una caja mágica sin configuración. No hay registro, ni telemetría, ni ventas adicionales. Funciona completamente en tu máquina bajo tu propia suscripción de Claude Code.
+
+## Estado de mantenimiento
+
+**Mantenimiento activo.** Este kit se actualiza con el tiempo a medida que sus mantenedores aprenden qué funciona y conforme Claude Code evoluciona, así que espera que siga mejorando. Sigues siendo dueño absoluto de tu copia: haz fork, cámbialo todo, aléjate todo lo que quieras. Las issues y PRs son bienvenidas; las revisiones se hacen con el tiempo disponible, ya que el kit se mantiene junto con otros trabajos.
+
+## Verlo en acción
+
+![Ejecutando ./setup.sh: Compabob hace algunas preguntas y luego crea tu espacio de trabajo en aproximadamente un minuto.](../assets/demo.png)
+
+Un solo script. Te pregunta quién eres y qué haces, crea tu vault, memoria y configuración a partir de las semillas incluidas, aplica un preset de personalidad y ya estás listo para empezar.
+
+## Inicio rápido
+
+¿Te manejas con la terminal? Tres comandos:
+
+```bash
+git clone https://github.com/chacosoldier/compabob.git
+cd compabob
+./setup.sh
+```


### PR DESCRIPTION
Closes #9

Adds documentation for setting default model (settings.local.json, --model flag) and per-agent model (agent frontmatter). Covers trade-offs and a worked example.