### PR TITLE
feat: add researcher persona preset (academia / R&D)

### DIFF
--- a/config/personas/README.md
+++ b/config/personas/README.md
@@ -26,6 +26,7 @@ It is applied once, at setup. If you have already edited
 | `engineer` | Shipping software and owning technical decisions. |
 | `sales` | Pipeline, deals, accounts, quota. |
 | `founder` | Running a business: strategy, fundraising, hiring, product. |
+| `researcher` | Academia and R&D: literature surveys, paper drafting, experiments. |
 
 ## Add your own
 

--- a/config/personas/researcher.md
+++ b/config/personas/researcher.md
@@ -1,0 +1,53 @@
+---
+id: researcher
+label: Researcher / academia
+---
+
+# Role and priorities
+
+> What you are responsible for and what you are trying to move right now. The
+> assistant reads this to tell on-strategy work from distractions. Review it
+> monthly; priorities go stale fast. This file was pre-filled from the
+> "Researcher" persona you picked at setup. Edit every bracket to fit you.
+
+## What you work on
+
+<WHAT_YOU_WORK_ON>
+
+## Role
+
+[your title, e.g. PhD Candidate / Postdoc / R&D Scientist]. You advance knowledge
+through research: designing studies, running experiments, analysing results, and
+publishing findings.
+
+## What you own
+
+- [the research question, thesis, or R&D programme you are pursuing]
+- [the literature survey and how you stay current in your field]
+- [the experiments, simulations, or studies in flight]
+- [the papers, reports, or deliverables you are drafting or revising]
+- [the data, code, or lab notebooks underpinning your work]
+
+## Priorities this quarter
+
+> Convert any deadline to an absolute date. Rank them; the order is the point.
+
+1. [the submission deadline, conference, or milestone that matters most]
+2. [the experiment or analysis that unblocks the next step]
+3. [the literature you need to review or the gap you need to close]
+
+## Explicitly not doing
+
+- [projects, collaborations, or tangents you have decided to pause — naming
+  them lets the assistant flag a scope creep risk]
+
+## Where the assistant helps most
+
+Use `second-brain` to keep notes, references, and experiment logs linked so
+nothing falls through the cracks. Bring data and figures to `analyst` to turn
+raw results into publication-ready tables and plots. Run `/morning-brief` to
+review what is due and what changed in your field. `/log-decision` records the
+methodological calls you may need to justify during peer review. Lean on
+`first-principles` when a hard research design or interpretation question needs
+structured reasoning, and `comms-meetings` for co-author correspondence and
+conference logistics. All other agents stay available.

--- a/setup.sh
+++ b/setup.sh
@@ -41,15 +41,16 @@ ask PRIMARY_LANGUAGE "Your main working language"          "English"
 echo
 
 bold "Which best describes your work?"
-echo "  1) generalist   2) consultant   3) engineer   4) sales   5) founder"
-ask PERSONA_PICK "Pick 1-5 (or the name)" "1"
+echo "  1) generalist   2) consultant   3) engineer   4) sales   5) founder   6) researcher"
+ask PERSONA_PICK "Pick 1-6 (or the name)" "1"
 case "$PERSONA_PICK" in
-  1|generalist) PERSONA=generalist;;
-  2|consultant) PERSONA=consultant;;
-  3|engineer)   PERSONA=engineer;;
-  4|sales)      PERSONA=sales;;
-  5|founder)    PERSONA=founder;;
-  *)            warn "did not recognize \"$PERSONA_PICK\" — using generalist"; PERSONA=generalist;;
+  1|generalist)  PERSONA=generalist;;
+  2|consultant)  PERSONA=consultant;;
+  3|engineer)    PERSONA=engineer;;
+  4|sales)       PERSONA=sales;;
+  5|founder)     PERSONA=founder;;
+  6|researcher)  PERSONA=researcher;;
+  *)             warn "did not recognize \"$PERSONA_PICK\" — using generalist"; PERSONA=generalist;;
 esac
 ask WORK_ON "In a sentence or two, what do you work on" ""
 echo


### PR DESCRIPTION
Closes #7

Adds config/personas/researcher.md tailored for literature surveys, paper drafting, citation management, reading-list triage, and experiment logs. Wires into setup.sh picker and apply_persona.