### PR TITLE
docs: add Linux troubleshooting quick hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ Run `bash scripts/init.sh`. It checks your setup and tells you, in plain languag
 ### Linux and Windows
 
 - **Linux**: skip Homebrew. Install the tools with your package manager, for example `sudo apt install git nodejs npm python3`, then do steps 4 to 7.
+- **If something looks wrong on Linux**: WSL sometimes ships `nodejs` + `npm`, so add `sudo ln -s /usr/bin/nodejs /usr/local/bin/node` if a script cannot find `node`.
+- Fedora/RHEL: `sudo dnf install git nodejs python3`.
+- Arch: `sudo pacman -S git nodejs npm python`.
+- Check `python3 --version` returns 3.10+ before `./setup.sh`.
+- If `./setup.sh` says "Permission denied," run `chmod +x setup.sh` first.
 - **Windows**: install [WSL](https://learn.microsoft.com/windows/wsl/install) first (in PowerShell: `wsl --install`, then restart). Open the Ubuntu terminal it gives you and follow the Linux steps. Native Windows (PowerShell/cmd) is not supported.
 
 ## Updating


### PR DESCRIPTION
## Summary
- add a compact Linux troubleshooting block immediately after the existing Linux setup line in the README
- cover the WSL `nodejs`/`node` mismatch, Fedora/RHEL packages, Arch packages, Python 3.10+ verification, and the `chmod +x setup.sh` fix
- keep the section to one-line hints so it unblocks Linux users without duplicating distro docs

## Validation
- `git diff --check`

Closes #11
