### PR TITLE
feat(v1.2): chart-tufte + mcp-debug + memory-debt skills + tool-scope-guard hook

### DIFF
--- a/.claude/skills/chart-tufte/SKILL.md
+++ b/.claude/skills/chart-tufte/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: chart-tufte
+description: Self-grade rubric for any quantitative chart, grounded in Edward Tufte's *Visual Display of Quantitative Information*. Run as a final pass inside `visual-explainer` (or any chart-emitting workflow) before showing the chart to the user. Strips chartjunk, checks lie factor, picks the right genre, names the failure modes from VDQI's catalogue.
+---
+
+# Chart Tufte
+
+A chart is good when it shows the data, helps the viewer reason about it, and does not lie. Tufte spent a career formalising this. This skill collapses his principles into a self-grade pass that runs on any chart the assistant is about to emit.
+
+**Read [references/vdqi-catalogue.md](references/vdqi-catalogue.md) first** when grading. It holds the named-failures library (NYT MPG 14.8, TIME barrel 59.4, etc.) and the named-exemplars library (Minard, Marey, Playfair, Snow). The catalogue is what makes assessment diagnostic instead of generic.
+
+## When to invoke
+
+- **Automatically** — as the final step inside `visual-explainer` whenever the output is a *quantitative* chart (bar, line, scatter, area, dot, range-frame). Skip for diagrams (architecture, sequence, flow); those are different beasts.
+- **Explicitly** — `/chart-tufte <chart-spec>` to score a chart produced elsewhere.
+
+## The rubric (run before emitting)
+
+Score each on 0-10. Stop and revise if any score drops below 5.
+
+1. **Data-ink ratio** — does every pixel of ink represent data? Borders, gridlines, redundant legends are non-data ink. Target: tend toward 1.0; typical for default-styled charts is 0.1-0.2 (VDQI p.136).
+2. **Lie factor** — `(visual change %) / (data change %)`. Acceptable range 0.95-1.05. Cite a VDQI named failure if it is worse: TIME's barrel chart hit 59.4, NYT's MPG hit 14.8.
+3. **Data density** — numbers per square inch. Below 0.15 is overwrought (a single bar showing one number is the canonical sin). High-density alternatives: small multiples, range-frame scatters, tables.
+4. **Chartjunk count** — does the chart contain any of the four named species?
+   - **Moiré** — vibrating cross-hatch patterns.
+   - **The dreaded grid** — gridlines drawn darker than the data.
+   - **The duck** — visual gimmick that overwhelms the data (3D pies, gradient-shaded bars).
+   - **Decoration** — clip art, icons, mascots in the chart frame.
+   Each chartjunk species costs points.
+5. **Genre fit** — is this the right *shape* for this data?
+   - ≤20 numbers → table, not chart
+   - Many series → small multiples (one panel per series)
+   - 2 quantitative variables → range-frame scatter (axis only spans data min-max)
+   - Distribution → quartile plot, not bar of mean
+   - Time series → thin line + direct endpoint labels, no legend
+6. **Dimensionality discipline** — does the chart use more dimensions than the data has? A 3D pie chart on 1D data is dishonest by construction. Penalise.
+7. **Direct labelling** — are series labelled at their endpoint or inline, not via a separate legend? Legends force the reader's eye to bounce.
+8. **Range-frame discipline** — does the axis span only the data range, not 0 to some arbitrary max?
+9. **Comparability** — if multiple panels: same y-scale where comparison matters; different scales only when local shape is the question.
+
+## Remedies (when the rubric flags problems)
+
+- **B1 — fix lie factor**: redraw with proportional scaling. State the new lie factor in the chart caption.
+- **B2 — erase non-data ink**: remove borders, drop gridlines, kill the legend if direct labelling fits.
+- **B3 — increase data density**: switch to small multiples if you have ≥3 panels of comparable data.
+- **B4 — pick the right genre** (see C1-C10 below).
+- **B5 — name the failure**: if the chart resembles a VDQI named failure (NYT MPG 14.8, TIME barrel 59.4, LA Times shrinking-doctor 2.8, USA Today 3D bar chart, Playfair's wheat decline), say so before showing.
+- **B6 — fix dimensionality**: 1D data → 1D chart; never 3D unless the third dimension is *in* the data.
+- **B7 — deflate currency over time**: if plotting dollars across years, deflate to a common year (state which) before plotting. Failing to do this is a silent lie factor.
+
+## Genre playbook (C1-C10)
+
+- **C1 — quartile plot** for distributions (5-number summary, no whiskers gimmick).
+- **C2 — range-frame scatter** for two quantitative variables (axes span data range only).
+- **C3 — dot-dash marginals** on a range frame to show density on each axis.
+- **C4 — paired bars** for two-group comparison on one categorical axis.
+- **C5 — small multiples** for many series (1 panel per series, same x-axis, often same y-axis).
+- **C6 — sparkline** for inline time series at word-scale.
+- **C7 — slopegraph** for before/after comparison across many categories.
+- **C8 — stem-and-leaf table** when the goal is the actual numbers, not the shape.
+- **C9 — table** when ≤20 numbers and structure matters.
+- **C10 — thin line chart** for time series, direct endpoint label, no legend, no gridlines.
+
+## Exemplars to emulate
+
+- Minard's *Napoleon's March* (1869) — six variables, one image, time + space + temperature + casualties.
+- Playfair's wheat-vs-wages (1822) — currency deflated, dual y-axis used honestly.
+- Modern NYT inflation charts — direct labels, no gridlines, deflated currency.
+- Tufte's own sparkline-in-prose pattern — chart as part of the sentence.
+
+## Output
+
+A six-line block:
+
+```
+Tufte self-grade
+  Data-ink ratio: 7/10
+  Lie factor: 1.02 (acceptable; not in catalogue)
+  Chartjunk: 0 species
+  Genre fit: C10 (thin line) — correct for the data
+  Verdict: ship
+  Notes: (any remedies applied during pass)
+```
+
+If the verdict is not `ship`, revise the chart and re-grade before emitting.
+
+## Integration with `visual-explainer`
+
+Two integration points:
+
+1. **At plan time** — when `visual-explainer`'s aesthetic step picks a visual palette, ALSO pick a Tufte genre (C1-C10). Record both. Never combine the *aesthetic* with the *genre*.
+2. **At emit time** — run this rubric over the rendered HTML/SVG before opening it in the browser. If any score < 5, revise. Block on `verdict != ship`.
+
+## VDQI page references (for citations)
+
+- Data-ink ratio definition + targets: p.93, 136
+- Lie factor formula + named failures: pp.55-80
+- Chartjunk taxonomy (moiré / grid / duck / decoration): pp.107-121
+- Small multiples: pp.170-175
+- Range frame: pp.130-133
+- Sparklines (later book *Beautiful Evidence*, but cited in the canon)
+
+Edward Tufte, *The Visual Display of Quantitative Information*, 2nd ed., Graphics Press, 2001.

--- a/.claude/skills/chart-tufte/references/vdqi-catalogue.md
+++ b/.claude/skills/chart-tufte/references/vdqi-catalogue.md
@@ -1,0 +1,114 @@
+# VDQI catalogue — named failures, named exemplars, quantitative anchors
+
+Reference depth for the `chart-tufte` skill. The SKILL.md handles the rubric (9 criteria, 10 genres, 7 remedies). This file holds the *comparison libraries* that make assessment diagnostic.
+
+When grading a chart, the SKILL.md says "name the failure." This file holds the names. When recommending a redesign, the SKILL.md says "point to an exemplar." This file holds the exemplars.
+
+All citations are page numbers in Edward Tufte, *The Visual Display of Quantitative Information*, 2nd ed., Graphics Press, 2001 (referred to below as VDQI).
+
+---
+
+## Named failures — comparison library
+
+Compare a flagged chart to one of these. Saying "this is essentially the 1979 TIME barrel — lie factor likely 50+" is more diagnostic than "looks distorted."
+
+| Source | Date | Failure mode | Tufte's metric | VDQI p. |
+|---|---|---|---|---|
+| New York Times, "Fuel Economy Standards" | 1978-08-09 | 1-D quantity drawn as 2-D shrinking-road area; date sizes held constant while road narrowed | **Lie factor 14.8** (53% data change rendered as 783% visual change) | 57-58 |
+| TIME, "IN THE BARREL" | 1979-04-09 | Oil prices drawn on 3-D barrels of varying volume | **Lie factor 9.4 (area) / 59.4 (volume)** — Tufte calls it "a record" | 62, 71 |
+| Washington Post, "OPEC Benchmark Prices" | 1979-03-28 | Varying-size oil derricks for 1-D price data | **Lie factor 9.5** (708% data → 6,700% visual) | 62 |
+| LA Times, "The Shrinking Family Doctor" | 1979-08-05 | 2-D area + perspective + wrong horizontal spacing for 1-D ratio data | **Lie factor 2.8** | 69 |
+| New York Times, "Commission Payments to Travel Agents" | 1978-08-08 | Half-year values plotted at full-year intervals — "the lie repeated four times over" | — | 54 |
+| Day Mines, Inc., Annual Report | 1974 | Hidden baseline at approximately -$4.2M concealed the 1970 loss | — | 54 |
+| NSF, *Science Indicators*, Nobel Prizes chart | 1976 | Irregular x-axis: seven 10-year intervals followed by one 4-year interval, faking a decline | — | 60 |
+| New York Times, OPEC Oil Prices | 1978-12-19 | Five different vertical scales on one chart; the same value renders **15.1× different** depending on which axis you read | — | 61 |
+| New York Times, "NY State Total Budget Expenditures" | 1976-02-01 | Fake 3-D rendering plus raw (un-deflated) dollars to suggest explosive growth | — | 66-68 |
+| Fiorina, *Congress: Keystone of the Washington Establishment* | 1977 | No deflation of monetary series, plus tall-thin aspect ratio (2.7:1 taller than wide) | — | 66 |
+| Satet, *Les Graphiques* | 1932 | Men of varying body sizes representing export growth (area encoding for 1-D data) | — | 69 |
+| Pittsburgh Civic Commission report | 1911 | Buildings sized by height alone, ignoring area effect | — | 55 |
+| Dewey & Dakin, *Cycles: The Science of Prediction* | 1947 | "Solar Radiation and Stock Prices" — implied causation between unrelated series | Tufte: "a silly theory means a silly graphic" | 15 |
+
+### How to use this table
+
+When `chart-tufte` flags a problem, scan this table for the closest match.
+
+- 1-D data drawn as area or volume → **NYT MPG (14.8)** for area, **TIME barrel (59.4)** for volume.
+- Hidden or shifted baseline → **Day Mines (1974)**.
+- Inconsistent x-axis intervals → **NSF Nobel Prizes (1976)**.
+- Multiple y-axis scales on one chart → **NYT OPEC (1978-12-19, 15.1× variation)**.
+- Un-deflated monetary series → **Fiorina (1977)**.
+- Implied causation between independent series → **Dewey & Dakin (1947)**.
+
+State the comparison verbatim in the grade output: "This resembles the 1979 LA Times shrinking-family-doctor — lie factor 2.8."
+
+---
+
+## Named exemplars — success library
+
+When proposing a redesign, point at a specific exemplar to emulate. "This data calls for the Marey treatment" is concrete; "use direct labels" is generic.
+
+| Graphic | Creator / Year | Tufte's praise | What to copy |
+|---|---|---|---|
+| Napoleon's March on Russia | Charles Joseph Minard, 1869 | "It may well be the best statistical graphic ever drawn." | Stack 6 variables (army size, x, y, direction, temperature, date) in one image so the reader is "hardly aware they are looking into a world of four or five dimensions." |
+| Cholera map of Broad Street | Dr. John Snow, 1854 | "Graphical analysis testifies about the data far more efficiently than calculation." | Place events on geography; let the spatial cluster reveal cause. |
+| Paris-Lyon train schedule | E.J. Marey, 1885 | "Giving a context and order to complexity ... aesthetic balance." | Slope = speed; intersections = time + place. Mute grid to a soft gray so data dominates. |
+| *Commercial and Political Atlas* | William Playfair, 1786 | Playfair "invented or improved upon nearly all the fundamental graphical designs." | Eliminate non-data detail; use data-based grids that serve rather than fight the data. |
+| NYC Weather History | NYT, 1981-01-11 | "Successfully organizes a large collection of numbers, makes comparisons ... tells a story." | 181 numbers per square inch density; reserve full-page graphics for genuinely rich material (VDQI p.30, 164). |
+| Map of 1.3 Million Galaxies | Seldner et al., 1977 | "No other method for the display of statistical information is so powerful." | 110,000+ numbers per square inch (a record); varying greys rather than colors (VDQI p.166). |
+| Atlas of Cancer Mortality | Hoover et al., 1975 | "Attention has been directed toward exploring the substantive content of the data rather than methodology." | Massive data in small space via small multiples on a geographic base. |
+| LA Air Pollutants small multiples | McRae et al., 1979 | "Inevitably comparative, deftly multivariate, efficient in interpretation." | Repeat one design across panels; shift only the data, never the encoding. |
+| Thermal Conductivity of Cu/W | Ho, Powell, Liley, 1974 | "Effectively organizes a vast amount of data ... enforcing comparisons." | Double-functioning marks: coordinate labels ARE the data values. |
+| "Living" Histogram | Joiner, 1975 | "The data form the data measure." | Use the data as its own mark (photos of students arranged by height). |
+| Japanese Beetle Life Cycle | L. H. Newman, 1965 | "Ingeniously mixes space and time on the horizontal axis." | Encode space + time on the same axis when they correlate. |
+| Hannibal Campaign Map | Minard, 1869 | "Refined use of color ... calm, transparent colors." | Transparent flow colors layered over a visible base grid. |
+| Lambert's evaporation rate | J.H. Lambert, 1765 | "Most remarkable early ... non-analogical relational graphic." | Plot abstract quantity vs abstract quantity (the modern scatter plot). |
+| Consumer Reports reliability | 1982 | "Particularly ingenious mix of table and graphic." | Hybrid table-graphic for multi-variable comparison. |
+
+### How to use this table
+
+When the grader recommends a remedy, name the closest exemplar:
+
+- "Many series, comparable y-axis" → **McRae LA Air Pollutants** (small multiples).
+- "Multi-variable on one image" → **Minard's March** (stack 6 variables).
+- "Event data on geography" → **Snow's cholera map**.
+- "Time-table hybrid" → **Marey Paris-Lyon schedule**.
+- "Many numbers in small space" → **NYT NYC Weather History** (181 nrs/in²).
+- "Table beats chart" → **Consumer Reports 1982 hybrid**.
+
+---
+
+## Quantitative anchors
+
+Quick-reference numbers cited by page. Use these as concrete targets, not vague ideals.
+
+- **Lie factor** = (visual change %) / (data change %). Acceptable range **0.95-1.05** (VDQI p.57). Worst recorded cases: 14.8 (NYT MPG), 9.4 area / 59.4 volume (TIME barrel).
+- **Data-ink ratio** = data-ink / total-ink, equivalently `1.0 - proportion erasable without data loss` (VDQI p.93). Typical default charts: 0.1-0.2. Tufte's redesigns: edit toward ~1.0 (VDQI p.136).
+- **Data density** = entries / unit area. 0.15 numbers per square inch is "overwrought" (VDQI p.162). Aim for at least a few per square inch for ordinary work. Tufte's record exemplars reach 110,000-250,000 per square inch (VDQI pp.166-168).
+- **Dimensionality** (VDQI p.71): "The number of information-carrying dimensions depicted should not exceed the number of dimensions in the data." 1-D quantity → 1-D encoding (length or position). Never area for 1-D, never volume for 2-D.
+- **Tables vs charts**: for ≤20 numbers, default to a table (VDQI p.56). "A table is nearly always better than a dumb pie chart."
+- **Aspect ratio**: graphics should generally be wider than tall — "move toward horizontal graphics about 50 percent wider than tall" (VDQI p.190). Golden Rectangle ≈ 1.618 (VDQI p.189).
+- **Redundant-ink budget**: in one worked redesign Tufte erased approximately 65% of original ink with zero data loss (VDQI p.101). Most production charts have plenty to give back.
+- **Monetary time series**: deflate to real (constant-year) units before plotting. VDQI calls out Fiorina (VDQI p.66) for failing to do this.
+
+---
+
+## Decision tree — from data to genre
+
+Walk this top to bottom on any chart request. Stop at the first match.
+
+1. **≤20 numbers?** → Table (C9). Stop.
+2. **Distribution (single variable)?** → Quartile plot (C1).
+3. **Two quantitative variables, single series?** → Range-frame scatter (C2). Optional dot-dash marginals (C3).
+4. **Many series with same x-axis?** → Small multiples (C5). One panel per series, identical encoding.
+5. **Time series, single variable?** → Thin line chart (C10). Direct endpoint label. No legend. No gridlines. Range-frame axes.
+6. **Before/after across many categories?** → Slopegraph.
+7. **Geographic event data?** → Dotted map on geography (Snow exemplar).
+8. **Word-scale, inline?** → Sparkline.
+
+If none of the above fit, you're likely in a genre Tufte didn't endorse. Reconsider whether a chart is the right answer at all.
+
+---
+
+## Reference
+
+Edward Tufte, *The Visual Display of Quantitative Information*, 2nd ed., Graphics Press, 2001. ISBN 978-0961392147. All page numbers cited above refer to this edition.

--- a/.claude/skills/mcp-debug/SKILL.md
+++ b/.claude/skills/mcp-debug/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: mcp-debug
+description: "MCP server health check, tool tracing, and audit. Use when MCP tools fail silently, to check server status, or for periodic system audits. Trigger: /mcp-debug [status|trace|audit]"
+---
+
+# MCP Debugger
+
+A diagnostic tool for MCP (Model Context Protocol) server health and tool execution. Helps identify why MCP tools fail, which servers are down, and which servers are unused or redundant.
+
+Reads MCP config from the two standard locations:
+- `~/.claude.json` — user-scope servers.
+- `<project>/.mcp.json` — project-scope servers.
+
+## Mode detection
+
+Check the arguments:
+- No args or `status` — health check all configured MCP servers.
+- `trace <tool-name>` — trace a specific tool's configuration and likely failure modes.
+- `audit` — full audit with recommendations (unused servers, error patterns, consolidation candidates).
+
+## Mode 1: Status (default)
+
+### Steps
+
+1. List configured servers via the Claude Code CLI:
+   ```bash
+   claude mcp list
+   ```
+   If the CLI is unavailable, parse `~/.claude.json` (top-level `mcpServers`) and `./.mcp.json` directly.
+
+2. For each server, run the lightweight connectivity check appropriate to its transport:
+   - **stdio** — confirm the command exists on `$PATH` (`which <bin>`) and the wrapper script is executable.
+   - **http / sse** — `curl -s -o /dev/null -w "%{http_code}"` the URL.
+   - **Authenticated remote** — a `401` or `403` means *reachable*, not *down*. Flag as `auth` rather than `error`.
+
+3. Present a status table:
+
+   | Server | Transport | Status | Note |
+   |---|---|---|---|
+   | foo | stdio | ok | |
+   | bar | http | auth | 401 — token may need refresh |
+   | baz | stdio | error | binary not on PATH |
+
+4. For `warning`/`error` rows, propose the next debugging step (install the binary, refresh the token, check the env var).
+
+### Output
+
+```
+## MCP Server Status
+
+[table]
+
+### Issues found
+- <server>: <description + suggested fix>
+
+### Summary
+[X] ok | [Y] warnings | [Z] errors out of [N] servers
+```
+
+## Mode 2: Trace
+
+### Steps
+
+1. Parse the tool name from args (e.g. `/mcp-debug trace some-tool`).
+
+2. Find which server provides this tool. The MCP tool naming convention is `mcp__<server-slug>__<tool-name>`; the server slug maps back to a key in `~/.claude.json` or `.mcp.json`.
+
+3. Show the server's configuration:
+   - Transport (stdio / http / sse).
+   - Command or URL.
+   - Args.
+   - Env vars (always **redact secrets** — show `***` instead of values for any key matching `(?i)(token|key|secret|password)`).
+
+4. Classify the likely failure mode:
+   - **Auth expired** — OAuth token needs refresh.
+   - **Schema mismatch** — tool expects different parameters than what was sent.
+   - **Timeout** — server takes too long to respond.
+   - **Server down** — process crashed or port unreachable.
+   - **Config error** — missing env var, wrong path, or stale wrapper script.
+
+### Output
+
+```
+## Tool trace: <tool-name>
+
+Server: <server>
+Transport: stdio | http | sse
+Command / URL: <value>
+Status: <from health check>
+
+### Configuration
+[relevant config — secrets redacted]
+
+### Likely cause
+<classification + suggested fix>
+```
+
+## Mode 3: Audit
+
+### Steps
+
+1. Run the status check (Mode 1) for the full server list.
+
+2. If tool-usage telemetry exists (some projects log to `data/performance/session-log.jsonl` or similar), summarise the last 7 days:
+   - Tools called per server.
+   - Error rate per server.
+   - Most-used and least-used servers.
+
+3. Identify:
+   - **Unused servers** — configured but never called. Candidates for removal (each one adds startup overhead).
+   - **High-error servers** — called often but failing frequently.
+   - **Duplicate capabilities** — multiple servers providing similar tools.
+   - **Missing servers** — tools referenced in agents/skills but no server configured.
+
+### Output
+
+```
+## MCP audit report
+Date: YYYY-MM-DD
+Servers: <N> configured
+
+### Health summary
+[status table]
+
+### Usage (last 7 days)
+| Server | Calls | Errors | Error rate |
+|---|---|---|---|
+[from session logs, or "no usage data available"]
+
+### Recommendations
+1. Remove: <servers not used in 7+ days, with rationale>
+2. Fix: <servers with high error rates>
+3. Consolidate: <servers with overlapping capabilities>
+4. Add: <missing servers referenced by agents>
+```
+
+## Constraints
+
+- **Never expose secrets.** Redact API keys, tokens, passwords in every output.
+- **Read-only.** This skill does not start, stop, or modify any servers or config.
+- **Do not delete servers** without explicit user approval.
+- **`401`/`403`/`405` on URL servers** = reachable, not down. Mark as `auth` so the operator knows to refresh credentials rather than restart the server.
+
+## Quality checklist
+
+- [ ] All MCP config locations checked (`~/.claude.json` + `.mcp.json`).
+- [ ] Secrets redacted in every output line.
+- [ ] False-positive warnings (e.g. spaces in command paths handled by the shell) are flagged as such, not as errors.
+- [ ] Recommendations include a one-line rationale, not just an action.

--- a/.claude/skills/memory-debt/SKILL.md
+++ b/.claude/skills/memory-debt/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: memory-debt
+description: Review and apply pending memory updates that earlier sessions proposed but never wrote. Use `/memory-debt` to see what is pending, `/memory-debt apply` to resolve it interactively.
+---
+
+# Memory Debt Resolution
+
+You are a memory hygiene tool. Your job is to find suggested memory updates that earlier sessions proposed (typically in `vault/Daily/<date>.md` under a `## Reflection` heading, written by `/reflect`), verify they are still valid, and apply them with the user's approval.
+
+Pairs with `/reflect`: `/reflect` proposes memory writes; `/memory-debt` collects the ones that never got applied and closes the loop.
+
+## Mode detection
+
+Check args:
+- No args or `review` — Review Mode (show pending items).
+- `apply` — Apply Mode (resolve all pending items interactively).
+
+## Review Mode (default)
+
+### 1. Scan reflection sources
+
+Read in this order, stopping when at least one returns content:
+
+1. `vault/Daily/*.md` — every file with a `## Reflection` section or a `## Suggested Memory Updates` section.
+2. `vault/Reflections/*.md` — older convention.
+3. `vault/Journal/*.md` — alternate convention.
+
+For each file, extract:
+- "Suggested Memory Updates" entries (each starts with `- [ ]` or `- [x]`).
+- Free-text proposals under a `## Memory` or `## Memory Debt` heading.
+
+### 2. Classify each unchecked item
+
+For every `- [ ]` entry:
+1. Read the target file mentioned in the proposal. If no target is named, default to `memory/topics/<slug>.md` derived from the proposal title.
+2. Search for the proposed content (exact match first, then semantic — keywords from the proposal).
+3. Classify as:
+   - **APPLIED** — content already exists in the target file. Tick the diary entry to `- [x]` silently.
+   - **PENDING** — content not found, proposal is < 3 days old.
+   - **STALE** — content not found, proposal is 3+ days old.
+   - **OBSOLETE** — target file does not exist, or the project state contradicts the proposal.
+
+### 3. Present summary
+
+```
+## Memory Debt Report
+
+| # | Date | Target | Suggestion | Status | Age |
+|---|---|---|---|---|---|
+| 1 | YYYY-MM-DD | memory/topics/<slug>.md | <one-line summary> | PENDING | 1d |
+
+**Totals**: X pending, Y stale, Z already applied (silent fixes), W obsolete
+```
+
+## Apply Mode (`/memory-debt apply`)
+
+### 1. Run Review Mode first
+Build the full pending/stale/obsolete list.
+
+### 2. Interactive resolution
+
+For each PENDING or STALE item (oldest first), present:
+1. The original suggestion (from the diary).
+2. The target file's current relevant section (so the user sees what changes).
+3. The exact text to add or modify.
+
+Ask: **Apply / Skip / Edit / Obsolete**.
+
+### 3. Execute approved changes
+
+For each approved item:
+1. Read the target file.
+2. Apply the change (`Edit` or append).
+3. If the target file is new and lives at `memory/topics/<slug>.md`, also add a one-line pointer to `memory/MEMORY.md` so the index stays current.
+4. Update the diary entry from `- [ ]` to `- [x]`.
+
+### 4. Report
+
+Final summary: X applied, Y skipped, Z marked obsolete, W silent fixes.
+
+## Constraints
+
+- **Never auto-apply.** Always present each item for approval before modifying any file.
+- **Read before writing.** If the content already exists, mark APPLIED silently — never duplicate.
+- **MEMORY.md line cap.** If the constitution sets a limit (commonly ~200 lines), and writing the proposal would breach it, suggest a topic file in `memory/topics/` and a one-line index pointer instead of inlining.
+- **Diary edits are minimal.** Only flip checkboxes and update Memory Debt table status. Never rewrite proposal text.
+- **Oldest first.** Process chronologically so the longest-overdue debt clears first.
+
+## Quality checklist
+
+- [ ] All reflection sources scanned (`vault/Daily/`, `vault/Reflections/`, `vault/Journal/`).
+- [ ] Each proposal's target file is actually read before classifying.
+- [ ] No duplicate content is written.
+- [ ] Diary checkboxes are updated after each application.
+- [ ] `memory/MEMORY.md` stays under any configured line cap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ All notable changes to Compabob are recorded here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`/chart-tufte` skill** — self-grade rubric for any quantitative chart,
+  grounded in Edward Tufte's *Visual Display of Quantitative Information*.
+  Nine criteria, ten genres, seven remedies, plus a 114-line
+  `references/vdqi-catalogue.md` with named failures (NYT MPG 14.8, TIME
+  barrel 59.4) and named exemplars (Minard, Marey, Snow, Playfair). Designed
+  to run as the final pass inside `/visual-explainer` whenever the output is
+  a chart.
+- **`/mcp-debug` skill** — health-check, trace, or audit your configured MCP
+  servers when tools fail silently. Three modes: `status` (per-server
+  reachability), `trace <tool>` (likely failure mode for one tool), `audit`
+  (recommendations for unused / high-error / duplicate servers). Reads
+  `~/.claude.json` and `./.mcp.json`; redacts secrets in every output.
+- **`/memory-debt` skill** — review and apply memory updates that earlier
+  sessions proposed but never wrote. Scans `vault/Daily/`, `vault/Reflections/`,
+  and `vault/Journal/` for `- [ ]` proposals from `/reflect`, classifies each
+  as PENDING / STALE / OBSOLETE / APPLIED, then in `apply` mode walks through
+  approvals one by one. Closes the loop between `/reflect` (proposes) and
+  `memory/`.
+- **Tool-scope-guard hook** (`hooks/hook-tool-scope-guard.sh` +
+  `tool_scope_check.py` + `tool_scopes.yaml`) — a context-scoped PreToolUse
+  guard. Reasoning stays unconstrained; only the outward action surface
+  (sends, mutations, external writes) is bounded per execution context.
+  Pre-wired contexts: `interactive` (allow-all), `pulse` (overnight headless,
+  no sends), `morning-briefing` (read inboxes, write vault), `email-triage`
+  (label only, no send), `news-digest` (fetch + write only). Context is
+  selected via `$CLAUDE_CONTEXT` env var or `/tmp/claude-context-<session>`
+  file. Fail-open by design; blocks are logged to
+  `data/performance/tool-scope-blocks.jsonl`. Opt-in: add the hook entry to
+  `.claude/settings.json` under `PreToolUse` to activate.
+
+### Documented
+
+- **Choosing the Claude model** — new README section explains how to swap
+  the default model per session (`/model` or `--model`), per project
+  (`.claude/settings.json` → `"model"`), or globally (`ANTHROPIC_MODEL` env
+  var), with a pointer to the Anthropic model list. Closes #9.
+
 ## [1.1.1] — 2026-05-24
 
 Bug-fix release from the same-day QA pass. 5 personas × 10 input edge

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ Do not configure everything at once. Get one loop working end to end:
 
 That second-brain loop is the core value. Once it feels useful, expand from there using the [customization guide](docs/customization-guide.md).
 
+## Choosing the Claude model
+
+Compabob does not pin a model. It uses whatever Claude Code is configured to use — by default that is Sonnet, which is the right balance for most work.
+
+Three ways to change it:
+
+- **Per session** — type `/model` inside Claude Code and pick from the list, or start the CLI with a flag: `claude --model sonnet`.
+- **Per project** — add a `"model"` field to `.claude/settings.json` (alongside `outputStyle`). Aliases `"sonnet"`, `"opus"`, `"haiku"` are accepted, or paste a full model ID such as `"claude-sonnet-4-6"`.
+- **Globally** — set the `ANTHROPIC_MODEL` environment variable.
+
+Current model IDs are listed in the [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models). If a model is retired, the CLI falls back to the closest current one and prints a warning.
+
 ## What is inside
 
 ```
@@ -208,6 +220,9 @@ Skills are slash-command workflows. Type the command; the assistant runs the pro
 | `/visual-explainer` | Turn a system, plan, or dataset into a self-contained HTML page |
 | `/document-export` | Create a PDF, Excel, or Word file from your content |
 | `/weekly-review` | End-of-week review: done, slipped, decisions, commitments, next week's top 3 |
+| `/chart-tufte` | Self-grade any chart against Tufte's *Visual Display of Quantitative Information* before showing it |
+| `/mcp-debug` | Health-check, trace, or audit your MCP servers when tools fail silently |
+| `/memory-debt` | Resolve memory updates that earlier sessions proposed but never wrote |
 
 ## Modules (opt-in)
 

--- a/hooks/hook-tool-scope-guard.sh
+++ b/hooks/hook-tool-scope-guard.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# PreToolUse hook: context-scoped action-surface guard.
+#
+# Checks each tool call against hooks/tool_scopes.yaml for the active context.
+# Reasoning is unconstrained; only the action surface (sends, mutations,
+# external writes) is bounded per context.
+#
+# Context detection order:
+#   1. $CLAUDE_CONTEXT env var          (set by cron scripts / orchestrators)
+#   2. /tmp/claude-context-<session_id> (written by skills at session start)
+#   3. Default: "interactive"           (allow_all — no behavior change)
+#
+# Fail-open: YAML parse errors, unknown contexts, or missing scopes file all
+# fall through as allow. A broken guard must never block real work.
+#
+# Blocks are logged to data/performance/tool-scope-blocks.jsonl so operators
+# can tighten the scopes file based on what was actually attempted.
+
+set -uo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCOPES_FILE="$PROJECT_DIR/hooks/tool_scopes.yaml"
+CHECKER="$PROJECT_DIR/hooks/tool_scope_check.py"
+LOG_FILE="$PROJECT_DIR/data/performance/tool-scope-blocks.jsonl"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
+
+# No tool name — fail open.
+[ -z "$TOOL_NAME" ] && exit 0
+
+# Detect active context.
+CONTEXT="${CLAUDE_CONTEXT:-}"
+if [ -z "$CONTEXT" ] && [ -f "/tmp/claude-context-${SESSION_ID}" ]; then
+    CONTEXT=$(cat "/tmp/claude-context-${SESSION_ID}" 2>/dev/null | tr -d '[:space:]')
+fi
+CONTEXT="${CONTEXT:-interactive}"
+
+# Scopes file or checker missing — fail open.
+[ ! -f "$SCOPES_FILE" ] && exit 0
+[ ! -f "$CHECKER" ] && exit 0
+
+# Run checker. Prefer `uv run --script` (PEP-723 inline deps, no global install);
+# fall back to plain `python3` if uv is not available and pyyaml is on the path.
+if command -v uv >/dev/null 2>&1; then
+    RESULT=$(uv run --script "$CHECKER" "$TOOL_NAME" "$CONTEXT" "$SCOPES_FILE" 2>/dev/null)
+else
+    RESULT=$(python3 "$CHECKER" "$TOOL_NAME" "$CONTEXT" "$SCOPES_FILE" 2>/dev/null)
+fi
+
+# Parse verdict — default allow on any failure.
+VERDICT=$(echo "$RESULT" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin).get('verdict','allow'))" 2>/dev/null \
+  || echo "allow")
+REASON=$(echo "$RESULT" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin).get('reason','parse_error'))" 2>/dev/null \
+  || echo "parse_error")
+
+if [ "$VERDICT" = "deny" ]; then
+    mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+    printf '%s\n' \
+      "{\"ts\":\"$TIMESTAMP\",\"session\":\"$SESSION_ID\",\"context\":\"$CONTEXT\",\"tool\":\"$TOOL_NAME\",\"reason\":\"$REASON\"}" \
+      >> "$LOG_FILE" 2>/dev/null || true
+
+    # Build a safe JSON message (python handles quoting).
+    MSG=$(python3 -c \
+      "import json,sys; t,c=sys.argv[1],sys.argv[2]; print(json.dumps(f'Tool {t!r} is not permitted in context {c!r}. Edit hooks/tool_scopes.yaml to update the allowlist.'))" \
+      "$TOOL_NAME" "$CONTEXT" 2>/dev/null \
+      || echo '"Tool blocked by scope guard."')
+
+    python3 -c "
+import json, sys
+msg = $MSG
+print(json.dumps({
+    'hookSpecificOutput': {
+        'hookEventName': 'PreToolUse',
+        'permissionDecision': 'deny',
+        'permissionDecisionReason': msg
+    }
+}))
+" 2>/dev/null
+    exit 0
+fi
+
+exit 0

--- a/hooks/tool_scope_check.py
+++ b/hooks/tool_scope_check.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["pyyaml"]
+# ///
+"""Check whether a tool is permitted under the active context.
+
+Usage: python3 tool_scope_check.py <tool_name> <context> <scopes_yaml_path>
+Stdout: JSON {"verdict": "allow"|"deny", "reason": "<str>"}
+Exit: always 0 (callers check verdict, not exit code).
+
+Fail-open: if anything goes wrong (missing args, YAML parse error, unknown
+context), the verdict is "allow" with an explanatory reason. A broken guard
+must never block real work — operators inspect logs to tighten it later.
+"""
+import fnmatch
+import json
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) < 4:
+        print(json.dumps({"verdict": "allow", "reason": "missing_args"}))
+        return
+
+    tool, context, scopes_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    try:
+        import yaml  # noqa: PLC0415 — intentional late import (uv-injected dep)
+        with open(scopes_path) as f:
+            scopes = yaml.safe_load(f)
+    except Exception as e:
+        print(json.dumps({"verdict": "allow", "reason": f"yaml_error:{e}"}))
+        return
+
+    contexts = scopes.get("contexts", {})
+
+    if context not in contexts:
+        print(json.dumps({"verdict": "allow", "reason": f"unknown_context:{context}"}))
+        return
+
+    ctx = contexts[context]
+    policy = ctx.get("policy", "allow_all")
+
+    if policy == "allow_all":
+        print(json.dumps({"verdict": "allow", "reason": "allow_all_context"}))
+        return
+
+    blocked = ctx.get("blocked_tools") or []
+    allowed = ctx.get("allowed_tools") or []
+
+    # Explicit block list wins over allowlist.
+    for pattern in blocked:
+        if fnmatch.fnmatch(tool, pattern):
+            print(json.dumps({"verdict": "deny", "reason": f"blocked:{pattern}"}))
+            return
+
+    for pattern in allowed:
+        if fnmatch.fnmatch(tool, pattern):
+            print(json.dumps({"verdict": "allow", "reason": f"allowed:{pattern}"}))
+            return
+
+    print(json.dumps({"verdict": "deny", "reason": "not_in_allowlist"}))
+
+
+main()

--- a/hooks/tool_scopes.yaml
+++ b/hooks/tool_scopes.yaml
@@ -1,0 +1,140 @@
+# tool_scopes.yaml — bound the action surface per execution context.
+#
+# Reasoning is unconstrained; only outward actions (sends, mutations, writes
+# to shared systems) are bounded per context. Edit this file at admin time
+# instead of changing hook code at runtime.
+#
+# Context detection (checked in order):
+#   1. $CLAUDE_CONTEXT env var       — set by cron / orchestrator before launch
+#   2. /tmp/claude-context-<session> — written by skills at session start
+#   3. Default: "interactive"        — fail-open; preserves unguarded behavior
+#
+# Policy types:
+#   allow_all   — unrestricted (interactive default).
+#   allowlist   — only tools matching an allowed_tools pattern pass.
+#
+# Tool patterns support fnmatch globs (e.g. `mcp__gmail__*`).
+# `blocked_tools` is checked BEFORE `allowed_tools` (explicit deny wins).
+#
+# Tweak the contexts below to match the cron jobs and headless tasks you
+# actually run. The examples are realistic starting points for a personal
+# assistant kit: an overnight pulse, a morning briefing, an email triage,
+# and a news digest.
+
+default_behavior: allow  # fail-open if context unknown or YAML unreadable
+
+contexts:
+
+  # ── Interactive ─────────────────────────────────────────────────────────────
+  interactive:
+    description: "Full interactive session with the user — no restrictions."
+    policy: allow_all
+
+  # ── Overnight pulse / headless task processing ──────────────────────────────
+  pulse:
+    description: >
+      Headless overnight processing. Broad read access and vault writes for
+      staging. No outbound sends. No calendar or external state mutations.
+    policy: allowlist
+    allowed_tools:
+      # Core filesystem
+      - Read
+      - Write
+      - Edit
+      - Glob
+      - Grep
+      - Bash
+      # Sub-agents (each child inherits CLAUDE_CONTEXT).
+      - Agent
+      - Task
+      # Time
+      - mcp__time__get_current_time
+      - mcp__time__convert_time
+      # Mail — read-only
+      - mcp__*__search_threads
+      - mcp__*__get_thread
+      - mcp__*__list_labels
+      - mcp__*__list_drafts
+      # Calendar — read-only
+      - mcp__*__list_events
+      - mcp__*__get_event
+      - mcp__*__list_calendars
+      - mcp__*__suggest_time
+      # Web research
+      - WebFetch
+      - WebSearch
+    blocked_tools:
+      # No outbound mail under any circumstances.
+      - mcp__*__create_draft
+      - mcp__*__send_*
+      - mcp__*__label_*
+      - mcp__*__unlabel_*
+      # No calendar mutations.
+      - mcp__*__create_event
+      - mcp__*__update_event
+      - mcp__*__delete_event
+      - mcp__*__respond_to_event
+
+  # ── Morning briefing ────────────────────────────────────────────────────────
+  morning-briefing:
+    description: >
+      Read inboxes + calendar, write a briefing into the vault. No sends,
+      no calendar mutations, no external outbound.
+    policy: allowlist
+    allowed_tools:
+      - Read
+      - Write
+      - Edit
+      - Glob
+      - Grep
+      - Bash
+      - Agent
+      - mcp__time__get_current_time
+      - mcp__*__search_threads
+      - mcp__*__get_thread
+      - mcp__*__list_labels
+      - mcp__*__list_events
+      - mcp__*__get_event
+      - mcp__*__list_calendars
+    blocked_tools:
+      - mcp__*__create_draft
+      - mcp__*__send_*
+      - mcp__*__create_event
+      - mcp__*__update_event
+      - mcp__*__delete_event
+      - mcp__*__respond_to_event
+
+  # ── Email triage ────────────────────────────────────────────────────────────
+  email-triage:
+    description: >
+      Read, label, classify mail. Drafts allowed only via a separate review
+      flow — this context never sends.
+    policy: allowlist
+    allowed_tools:
+      - Read
+      - Write
+      - Bash
+      - mcp__*__search_threads
+      - mcp__*__get_thread
+      - mcp__*__list_labels
+      - mcp__*__label_message
+      - mcp__*__label_thread
+      - mcp__*__unlabel_message
+      - mcp__*__unlabel_thread
+    blocked_tools:
+      - mcp__*__create_draft
+      - mcp__*__send_*
+
+  # ── News digest ─────────────────────────────────────────────────────────────
+  news-digest:
+    description: >
+      Fetch + summarise the news, write a digest to the vault. No outbound.
+    policy: allowlist
+    allowed_tools:
+      - Read
+      - Write
+      - Edit
+      - Bash
+      - WebFetch
+      - WebSearch
+      - mcp__time__get_current_time


### PR DESCRIPTION
## Summary

Three slash-command skills and one opt-in PreToolUse hook, ported from the maintainer's personal kit after stripping personal references.

**Skills**

- `/chart-tufte` — self-grade any quantitative chart against Tufte's *Visual Display of Quantitative Information* (9 criteria, 10 genres, 7 remedies). Ships with a 114-line `references/vdqi-catalogue.md` of named failures (NYT MPG 14.8, TIME barrel 59.4) and named exemplars (Minard, Marey, Snow, Playfair). Intended to run as the final pass inside `/visual-explainer` whenever the output is a chart.
- `/mcp-debug` — health-check, trace, or audit configured MCP servers when tools fail silently. Three modes: `status` (per-server reachability), `trace <tool>` (likely failure mode for one tool), `audit` (recommendations). Reads `~/.claude.json` and `./.mcp.json`. Redacts secrets in every output.
- `/memory-debt` — resolve memory updates that earlier `/reflect` sessions proposed but never wrote. Scans `vault/Daily/`, `vault/Reflections/`, `vault/Journal/` for `- [ ]` proposals, classifies each as PENDING / STALE / OBSOLETE / APPLIED, and in `apply` mode walks approvals one by one. Closes the loop between `/reflect` and `memory/`.

**Hook (opt-in)**

- `hooks/hook-tool-scope-guard.sh` + `tool_scope_check.py` + `tool_scopes.yaml` — context-scoped PreToolUse guard. Reasoning stays unconstrained; only outward actions (sends, mutations, external writes) are bounded per context. Pre-wired contexts: `interactive`, `pulse`, `morning-briefing`, `email-triage`, `news-digest`. Context selected via `$CLAUDE_CONTEXT` env var or `/tmp/claude-context-<session>` file. Fail-open by design; blocks are logged to `data/performance/tool-scope-blocks.jsonl`. Opt-in: add the hook entry to `.claude/settings.json` under `PreToolUse` to activate.

**Also documented**

- New README section "Choosing the Claude model" explains how to swap models per session (`/model` or `--model`), per project (`.claude/settings.json` → `"model"`), or globally (`ANTHROPIC_MODEL`). Closes #9.

## Test plan

- [x] `bash -n` on every `.sh` (CI mirror) — all pass
- [x] yaml parses with all 5 contexts
- [x] hook end-to-end: allow case silent exit 0; deny case emits proper PreToolUse deny JSON; unknown context falls open; interactive default is allow-all
- [x] no maintainer-personal references leaked (grep over all new files returns clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
