### PR TITLE
docs(i18n): add Spanish translation of README intro (cherry-pick of #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Compabob
 
+[English](README.md) | [Español](docs/i18n/README.es.md)
+
 [![CI](https://github.com/chacosoldier/compabob/actions/workflows/smoke.yml/badge.svg)](https://github.com/chacosoldier/compabob/actions/workflows/smoke.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/chacosoldier/compabob?style=social)](https://github.com/chacosoldier/compabob/stargazers)

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -1,0 +1,40 @@
+# Compabob
+
+[English](../../README.md) | [Español](README.es.md)
+
+## Por qué
+
+Una sesión nueva de Claude Code es una generalista competente que no sabe nada de ti. Cada vez tienes que volver a explicarle quién eres, cómo quieres las respuestas y en qué estás trabajando. No tiene noción de tus prioridades, ni barreras de seguridad sobre lo que se envía, ni un lugar donde guardar lo que aprende.
+
+Compabob es la estructura que faltaba. El ciclo fundamental, desde el primer día:
+
+> Le pides que tome notas de la reunión de planificación de hoy. Las archiva en tu base de conocimiento. La semana siguiente, antes del seguimiento, escribes `/meeting-prep` y te devuelve los asistentes, lo que se decidió y los temas pendientes, sin que tengas que buscar nada.
+
+Ese ciclo de segundo cerebro es el valor que obtienes de inmediato. Compabob es un andamio, no un asistente terminado: todo lo demás se multiplica a medida que lo haces tuyo.
+
+## Qué es (y qué no es)
+
+- **Es**: una plantilla con opinión propia para un solo usuario. Arquitectura, convenciones y un conjunto de agentes, hooks y skills que requirieron verdadera iteración para dar en el clavo, empaquetados para que no empieces desde cero.
+- **No es**: un producto, un SaaS ni una caja mágica sin configuración. No hay registro, ni telemetría, ni ventas adicionales. Funciona completamente en tu máquina bajo tu propia suscripción de Claude Code.
+
+## Estado de mantenimiento
+
+**Mantenimiento activo.** Este kit se actualiza con el tiempo a medida que sus mantenedores aprenden qué funciona y conforme Claude Code evoluciona, así que espera que siga mejorando. Sigues siendo dueño absoluto de tu copia: haz fork, cámbialo todo, aléjate todo lo que quieras. Las issues y PRs son bienvenidas; las revisiones se hacen con el tiempo disponible, ya que el kit se mantiene junto con otros trabajos.
+
+## Verlo en acción
+
+![Ejecutando ./setup.sh: Compabob hace algunas preguntas y luego crea tu espacio de trabajo en aproximadamente un minuto.](../assets/demo.png)
+
+Un solo script. Te pregunta quién eres y qué haces, crea tu vault, memoria y configuración a partir de las semillas incluidas, aplica un preset de personalidad y ya estás listo para empezar.
+
+## Inicio rápido
+
+¿Te manejas con la terminal? Tres comandos:
+
+```bash
+git clone https://github.com/chacosoldier/compabob.git
+cd compabob
+./setup.sh
+```
+
+> Esta es una traducción parcial (las primeras seis secciones) del [README en inglés](../../README.md). Para la guía completa, incluyendo el tutorial paso a paso, las skills, los módulos y el resto, sigue el documento original. Traducción inicial aportada por [@MD-Mushfiqur123](https://github.com/MD-Mushfiqur123) en [#17](https://github.com/chacosoldier/compabob/pull/17).


### PR DESCRIPTION
## Summary

Adds a Spanish translation of the first six sections of the README at `docs/i18n/README.es.md`, plus a language switcher at the top of the main README.

Cherry-pick of #17 onto current main — PR #17's branch base was too old to fast-forward (it predated the badges row, the "how this differs" section, and the v1.1 / v1.2 work), and the GitHub `update-branch` API returned a server-side merge conflict. The substance ships here instead so the contributor's work is not lost.

**Fixes vs. #17**
- Image-alt cross-link in the Spanish file corrected from `../assets/demo.png` to `../assets/demo.png` (no change needed; verified resolves to `docs/assets/demo.png`).
- "English" cross-link in the Spanish file corrected from `../README.md` to `../../README.md` (PR #17 would have linked to `docs/README.md`, which does not exist).
- Closing note added pointing readers to the full English README for the rest.

**Credit**
- Translation by @MD-Mushfiqur123 in #17.

Closes #10. PR #17 will be closed with a pointer to this PR.

## Test plan

- [x] `bash -n` on every `.sh` (CI mirror)
- [x] both cross-links resolve from their actual filesystem positions
- [x] image link in Spanish file resolves to `docs/assets/demo.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
